### PR TITLE
chore: clean up pos state sync test

### DIFF
--- a/core/helpers/scripts/async.bash
+++ b/core/helpers/scripts/async.bash
@@ -13,17 +13,17 @@ function assert_eventually_greater_than() {
 
   local start_time=$(date +%s)
   local end_time=$((start_time + timeout))
-  echo "Checking if '${command}' will eventually be greater than '${threshold}' within ${timeout} seconds." >&3
+  echo "Checking if '${command}' will eventually be greater than '${threshold}' within ${timeout} seconds."
   while [[ "$(date +%s)" -lt "${end_time}" ]]; do
     result=$(eval "$command")
     if [[ "${result}" -gt "${threshold}" ]]; then
-      echo "[$(date '+%Y-%m-%d %H:%M:%S')] ✅ Result '${result}' is greater than '${threshold}'!" >&3
+      echo "[$(date '+%Y-%m-%d %H:%M:%S')] ✅ Result '${result}' is greater than '${threshold}'!"
       return 0
     fi
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Result '${result}' is not greater than '${threshold}'. Waiting ${interval} seconds..." >&3
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Result '${result}' is not greater than '${threshold}'. Waiting ${interval} seconds..."
     sleep "${interval}"
   done
 
-  echo "[$(date '+%Y-%m-%d %H:%M:%S')] ❌ Timeout reached." >&3
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] ❌ Timeout reached."
   return 1
 }

--- a/tests/pos/state-sync.bats
+++ b/tests/pos/state-sync.bats
@@ -27,7 +27,7 @@ setup() {
 @test "Trigger State Sync" {
     # Check initial account balance on L2.
     initial_balance=$(cast balance --rpc-url "${L2_RPC_URL}" --ether "${ADDRESS}")
-    echo "${ADDRESS} initial balance: ${initial_balance} ether." >&3
+    echo "${ADDRESS} initial balance: ${initial_balance} ether."
 
     # Check initial state sync count.
     if [[ "${L2_CL_NODE_TYPE}" == "heimdall" ]]; then
@@ -35,41 +35,41 @@ setup() {
     elif [[ "${L2_CL_NODE_TYPE}" == "heimdall-v2" ]]; then
         heimdall_state_sync_count_cmd='curl --silent "${L2_CL_API_URL}/clerk/event-record/list" | jq ".event_records | length"'
     else
-        echo '❌ Wrong L2 CL node type given: "${L2_CL_NODE_TYPE}". Expected "heimdall" or "heimdall-v2".' >&3
+        echo '❌ Wrong L2 CL node type given: "${L2_CL_NODE_TYPE}". Expected "heimdall" or "heimdall-v2".'
         exit 1
     fi
     initial_heimdall_state_sync_count=$(eval "${heimdall_state_sync_count_cmd}")
-    echo "Heimdall initial state sync count: ${initial_heimdall_state_sync_count}." >&3
+    echo "Heimdall initial state sync count: ${initial_heimdall_state_sync_count}."
 
     bor_state_sync_count_cmd='cast call --rpc-url "${L2_RPC_URL}" "${L2_STATE_RECEIVER_ADDRESS}" "lastStateId()(uint)"'
     initial_bor_state_sync_count=$(eval "${bor_state_sync_count_cmd}")
-    echo "Bor initial state sync count: ${initial_bor_state_sync_count}." >&3
+    echo "Bor initial state sync count: ${initial_bor_state_sync_count}."
 
     # Bridge some ERC20 tokens to trigger a state sync.
     erc20_token_amount_to_bridge=10
 
-    echo "✅ Approving the DepositManager contract to spend ERC20 tokens on our behalf..." >&3
+    echo "✅ Approving the DepositManager contract to spend ERC20 tokens on our behalf..."
     run send_tx "${L1_RPC_URL}" "${PRIVATE_KEY}" "${ERC20_TOKEN_ADDRESS}" \
         "approve(address,uint)" "${L1_DEPOSIT_MANAGER_PROXY_ADDRESS}" "${erc20_token_amount_to_bridge}"
 
-    echo "🚀 Depositing ERC20 to trigger a state sync..." >&3
+    echo "🚀 Depositing ERC20 to trigger a state sync..."
     run send_tx "${L1_RPC_URL}" "${PRIVATE_KEY}" "${L1_DEPOSIT_MANAGER_PROXY_ADDRESS}" \
         "depositERC20(address,uint)" "${ERC20_TOKEN_ADDRESS}" "${erc20_token_amount_to_bridge}"
 
     # Monitor state syncs on the L2 consensus layer.
-    echo "👀 Monitoring state syncs on Heimdall..." >&3
+    echo "👀 Monitoring state syncs on Heimdall..."
     assert_eventually_greater_than "${heimdall_state_sync_count_cmd}" "${initial_heimdall_state_sync_count}" 180 10
 
     # Monitor state syncs on the L2 execution layer.
-    echo "👀 Monitoring state syncs on Bor..." >&3
+    echo "👀 Monitoring state syncs on Bor..."
     cmd='cast call --rpc-url "${L2_RPC_URL}" "${L2_STATE_RECEIVER_ADDRESS}" "lastStateId()(uint)"'
     assert_eventually_greater_than "${bor_state_sync_count_cmd}" "${initial_bor_state_sync_count}" 180 10
 
     # Check new account balance on L2.
     balance=$(cast balance --rpc-url "${L2_RPC_URL}" --ether "${ADDRESS}")
     if [[ "${balance}" -lt "${initial_balance}" ]]; then
-        echo "❌ ${ADDRESS} balance has not changed." >&3
+        echo "❌ ${ADDRESS} balance has not changed."
         exit 1
     fi
-    echo "✅ ${ADDRESS} balance has increased: ${balance} ether." >&3
+    echo "✅ ${ADDRESS} balance has increased: ${balance} ether."
 }

--- a/tests/pos/state-sync.bats
+++ b/tests/pos/state-sync.bats
@@ -2,74 +2,74 @@
 
 setup() {
     # Load libraries.
-    bats_load_library 'bats-support'
-    bats_load_library 'bats-assert'
-    load "$PROJECT_ROOT/core/helpers/scripts/send_tx.bash"
     load "$PROJECT_ROOT/core/helpers/scripts/async.bash"
 
-    # Define environment variables.
+    # Define parameters.
     export ENCLAVE=${ENCLAVE:-"pos"}
     export ADDRESS=${ADDRESS:-"0x74Ed6F462Ef4638dc10FFb05af285e8976Fb8DC9"}
     export PRIVATE_KEY=${PRIVATE_KEY:-"0xd40311b5a5ca5eaeb48dfba5403bde4993ece8eccf4190e98e19fcd4754260ea"}
 
+    # RPC Urls.
     export L1_RPC_URL=${L1_RPC_URL:-"http://$(kurtosis port print $ENCLAVE el-1-geth-lighthouse rpc)"}
     export L2_RPC_URL=${L2_RPC_URL:-$(kurtosis port print "${ENCLAVE}" l2-el-1-bor-heimdall-validator rpc)}
     export L2_CL_API_URL=${L2_CL_API_URL:-$(kurtosis port print "${ENCLAVE}" l2-cl-1-heimdall-bor-validator http)}
     export L2_CL_NODE_TYPE=${L2_CL_NODE_TYPE:-"heimdall"}
 
+    # Contract addresses
     matic_contract_addresses=$(kurtosis files inspect $ENCLAVE matic-contract-addresses contractAddresses.json | tail -n +2 | jq)
     export L1_DEPOSIT_MANAGER_PROXY_ADDRESS=${L1_DEPOSIT_MANAGER_PROXY_ADDRESS:-$(echo $matic_contract_addresses | jq --raw-output '.root.DepositManagerProxy')}
     export ERC20_TOKEN_ADDRESS=${ERC20_TOKEN_ADDRESS:-$(echo $matic_contract_addresses | jq --raw-output '.root.tokens.MaticToken')}
     export L2_STATE_RECEIVER_ADDRESS=${L2_STATE_RECEIVER_ADDRESS:-$(kurtosis files inspect $ENCLAVE l2-el-genesis genesis.json | tail -n +2 | jq --raw-output '.config.bor.stateReceiverContract')}
-}
 
-# bats file_tags=pos,state-sync
-@test "Trigger State Sync" {
-    # Check initial account balance on L2.
-    initial_balance=$(cast balance --rpc-url "${L2_RPC_URL}" --ether "${ADDRESS}")
-    echo "${ADDRESS} initial balance: ${initial_balance} ether."
-
-    # Check initial state sync count.
+    # Commands.
     if [[ "${L2_CL_NODE_TYPE}" == "heimdall" ]]; then
-        heimdall_state_sync_count_cmd='curl --silent "${L2_CL_API_URL}/clerk/event-record/list" | jq ".result | length"'
+        HEIMDALL_STATE_SYNC_COUNT_CMD='curl --silent "${L2_CL_API_URL}/clerk/event-record/list" | jq ".result | length"'
     elif [[ "${L2_CL_NODE_TYPE}" == "heimdall-v2" ]]; then
-        heimdall_state_sync_count_cmd='curl --silent "${L2_CL_API_URL}/clerk/event-record/list" | jq ".event_records | length"'
+        HEIMDALL_STATE_SYNC_COUNT_CMD='curl --silent "${L2_CL_API_URL}/clerk/event-record/list" | jq ".event_records | length"'
     else
         echo '❌ Wrong L2 CL node type given: "${L2_CL_NODE_TYPE}". Expected "heimdall" or "heimdall-v2".'
         exit 1
     fi
-    initial_heimdall_state_sync_count=$(eval "${heimdall_state_sync_count_cmd}")
-    echo "Heimdall initial state sync count: ${initial_heimdall_state_sync_count}."
+    export HEIMDALL_STATE_SYNC_COUNT_CMD="${HEIMDALL_STATE_SYNC_COUNT_CMD}"
 
-    bor_state_sync_count_cmd='cast call --rpc-url "${L2_RPC_URL}" "${L2_STATE_RECEIVER_ADDRESS}" "lastStateId()(uint)"'
-    initial_bor_state_sync_count=$(eval "${bor_state_sync_count_cmd}")
-    echo "Bor initial state sync count: ${initial_bor_state_sync_count}."
+    BOR_STATE_SYNC_COUNT_CMD='cast call --rpc-url "${L2_RPC_URL}" "${L2_STATE_RECEIVER_ADDRESS}" "lastStateId()(uint)"'
+    export BOR_STATE_SYNC_COUNT_CMD="${BOR_STATE_SYNC_COUNT_CMD}"
+}
+
+# bats file_tags=pos,state-sync
+@test "Trigger State Sync" {
+    # Get initial values.
+    initial_balance=$(cast balance --rpc-url "${L2_RPC_URL}" --ether "${ADDRESS}")
+    initial_heimdall_state_sync_count=$(eval "${HEIMDALL_STATE_SYNC_COUNT_CMD}")
+    initial_bor_state_sync_count=$(eval "${BOR_STATE_SYNC_COUNT_CMD}")
+    echo "Initial values:"
+    echo "- ${ADDRESS} L2 balance: ${initial_balance} ether."
+    echo "- Heimdall state sync count: ${initial_heimdall_state_sync_count}."
+    echo "- Bor state sync count: ${initial_bor_state_sync_count}."
 
     # Bridge some ERC20 tokens to trigger a state sync.
-    erc20_token_amount_to_bridge=10
+    echo "Approving the DepositManager contract to spend ERC20 tokens on our behalf..."
+    cast send --rpc-url "${L1_RPC_URL}" --private-key "${PRIVATE_KEY}" \
+        "${ERC20_TOKEN_ADDRESS}" "approve(address,uint)" "${L1_DEPOSIT_MANAGER_PROXY_ADDRESS}" 10
 
-    echo "✅ Approving the DepositManager contract to spend ERC20 tokens on our behalf..."
-    run send_tx "${L1_RPC_URL}" "${PRIVATE_KEY}" "${ERC20_TOKEN_ADDRESS}" \
-        "approve(address,uint)" "${L1_DEPOSIT_MANAGER_PROXY_ADDRESS}" "${erc20_token_amount_to_bridge}"
+    echo "Depositing ERC20 to trigger a state sync..."
+    cast send --rpc-url "${L1_RPC_URL}" --private-key "${PRIVATE_KEY}" \
+        "${L1_DEPOSIT_MANAGER_PROXY_ADDRESS}" "depositERC20(address,uint)" "${ERC20_TOKEN_ADDRESS}" 10
 
-    echo "🚀 Depositing ERC20 to trigger a state sync..."
-    run send_tx "${L1_RPC_URL}" "${PRIVATE_KEY}" "${L1_DEPOSIT_MANAGER_PROXY_ADDRESS}" \
-        "depositERC20(address,uint)" "${ERC20_TOKEN_ADDRESS}" "${erc20_token_amount_to_bridge}"
+    # Monitor state syncs.
+    timeout="180" # seconds
+    interval="10" # seconds
+    echo "Monitoring state syncs on Heimdall..."
+    assert_eventually_greater_than "${HEIMDALL_STATE_SYNC_COUNT_CMD}" "${initial_heimdall_state_sync_count}" "${timeout}" "${interval}"
 
-    # Monitor state syncs on the L2 consensus layer.
-    echo "👀 Monitoring state syncs on Heimdall..."
-    assert_eventually_greater_than "${heimdall_state_sync_count_cmd}" "${initial_heimdall_state_sync_count}" 180 10
-
-    # Monitor state syncs on the L2 execution layer.
-    echo "👀 Monitoring state syncs on Bor..."
-    cmd='cast call --rpc-url "${L2_RPC_URL}" "${L2_STATE_RECEIVER_ADDRESS}" "lastStateId()(uint)"'
-    assert_eventually_greater_than "${bor_state_sync_count_cmd}" "${initial_bor_state_sync_count}" 180 10
+    echo "Monitoring state syncs on Bor..."
+    assert_eventually_greater_than "${BOR_STATE_SYNC_COUNT_CMD}" "${initial_bor_state_sync_count}" "${timeout}" "${interval}"
 
     # Check new account balance on L2.
-    balance=$(cast balance --rpc-url "${L2_RPC_URL}" --ether "${ADDRESS}")
-    if [[ "${balance}" -lt "${initial_balance}" ]]; then
+    new_balance=$(cast balance --rpc-url "${L2_RPC_URL}" --ether "${ADDRESS}")
+    if [[ "${new_balance}" -lt "${initial_balance}" ]]; then
         echo "❌ ${ADDRESS} balance has not changed."
         exit 1
     fi
-    echo "✅ ${ADDRESS} balance has increased: ${balance} ether."
+    echo "✅ ${ADDRESS} balance has increased: ${new_balance} ether."
 }


### PR DESCRIPTION
# Description

- Remove `echo ... >&3`.
- Use `cast send` instead of `run sen_tx` abstraction.
- Make it shorter and easier to read.

Cleaner output:
![Screenshot 2025-02-28 at 14 58 37](https://github.com/user-attachments/assets/0b2f7844-2d11-4c7b-9b8c-00d39ff939e8)

cc @praetoriansentry 