### PR TITLE
fix: add check for tags and commit hash for argsfiles

### DIFF
--- a/core/helpers/setup-kurtosis.sh
+++ b/core/helpers/setup-kurtosis.sh
@@ -21,7 +21,11 @@ echo "CUSTOM_AGGLAYER_IMAGE=${CUSTOM_AGGLAYER_IMAGE}"
 
 if [[ "${PACKAGE}" == "kurtosis-cdk" ]]; then
     ENCLAVE="cdk"
-    ARGS_FILE="https://raw.githubusercontent.com/0xPolygon/kurtosis-cdk/refs/tags/${VERSION}/${ARGS_FILE}"
+    if [[ ${VERSION:0:1} = "v" ]]; then
+        ARGS_FILE="https://raw.githubusercontent.com/0xPolygon/kurtosis-cdk/refs/tags/${VERSION}/${ARGS_FILE}"
+    else
+        ARGS_FILE="https://raw.githubusercontent.com/0xPolygon/kurtosis-cdk/${VERSION}/${ARGS_FILE}"
+    fi
     echo "ENCLAVE=${ENCLAVE}"
     echo "ARGS_FILE=${ARGS_FILE}"
 


### PR DESCRIPTION
This PR will fix an issue where if a commit hash is used for `VERSION`, it changes the URL accordingly so the `setup-kurtosis.sh` script will be able to correctly find the args .yml file.

<img width="1154" alt="Screenshot 2025-04-09 at 9 50 28 AM" src="https://github.com/user-attachments/assets/7dc621ec-6945-4808-8717-2ac8172b7e59" />
