### PR TITLE
feat: make agglayer bridge test work fine with most recent kurtosis-cdk main

### DIFF
--- a/tests/agglayer/bridges.bats
+++ b/tests/agglayer/bridges.bats
@@ -3,20 +3,20 @@
 setup() {
     l1_private_key=${L1_PRIVATE_KEY:-"12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625"}
     l1_eth_address=$(cast wallet address --private-key "$l1_private_key")
-    l1_rpc_url=${L1_RPC_URL:-"http://$(kurtosis port print cdk el-1-geth-lighthouse rpc)"}
-    l1_bridge_addr=${L1_BRIDGE_ADDR:-"0x12494fE98D3f67EB0c9e2512a4cd18e703aDe49d"}
+    l1_rpc_url=${L1_RPC_URL:-"http://$(kurtosis port print aggkit el-1-geth-lighthouse rpc)"}
+    l1_bridge_addr=${L1_BRIDGE_ADDR:-"0x9D86b4ec07d7e292F296Dad324b14C06F058a4f1"}
 
     l2_private_key=${L2_PRIVATE_KEY:-"12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625"}
     l2_eth_address=$(cast wallet address --private-key "$l2_private_key")
-    l2_rpc_url=${L2_RPC_URL:-"$(kurtosis port print cdk cdk-erigon-rpc-001 rpc)"}
-    l2_bridge_addr=${L2_BRIDGE_ADDR:-"0x12494fE98D3f67EB0c9e2512a4cd18e703aDe49d"}
+    l2_rpc_url=${L2_RPC_URL:-"$(kurtosis port print aggkit op-el-1-op-geth-op-node-001 rpc)"}
+    l2_bridge_addr=${L2_BRIDGE_ADDR:-"0x2E0309f8dDD1EeC27D41e623d73b25cfC4Bb4803"}
 
-    bridge_service_url=${BRIDGE_SERVICE_URL:-"$(kurtosis port print cdk zkevm-bridge-service-001 rpc)"}
+    bridge_service_url=${BRIDGE_SERVICE_URL:-"$(kurtosis port print aggkit zkevm-bridge-service-001 rpc)"}
     network_id=$(cast call  --rpc-url "$l2_rpc_url" "$l2_bridge_addr" 'networkID()(uint32)')
     claimtxmanager_addr=${CLAIMTXMANAGER_ADDR:-"0x5f5dB0D4D58310F53713eF4Df80ba6717868A9f8"}
     claim_wait_duration=${CLAIM_WAIT_DURATION:-"10m"}
 
-    agglayer_rpc_url=${AGGLAYER_RPC_URL:-"$(kurtosis port print cdk agglayer aglr-readrpc)"}
+    agglayer_rpc_url=${AGGLAYER_RPC_URL:-"$(kurtosis port print aggkit agglayer aglr-readrpc)"}
 
     fund_claim_tx_manager
 }

--- a/tests/agglayer/bridges.bats
+++ b/tests/agglayer/bridges.bats
@@ -14,7 +14,7 @@ setup() {
     bridge_service_url=${BRIDGE_SERVICE_URL:-"$(kurtosis port print aggkit zkevm-bridge-service-001 rpc)"}
     network_id=$(cast call  --rpc-url "$l2_rpc_url" "$l2_bridge_addr" 'networkID()(uint32)')
     claimtxmanager_addr=${CLAIMTXMANAGER_ADDR:-"0x5f5dB0D4D58310F53713eF4Df80ba6717868A9f8"}
-    claim_wait_duration=${CLAIM_WAIT_DURATION:-"10m"}
+    claim_wait_duration=${CLAIM_WAIT_DURATION:-"100m"}
 
     agglayer_rpc_url=${AGGLAYER_RPC_URL:-"$(kurtosis port print aggkit agglayer aglr-readrpc)"}
 


### PR DESCRIPTION
With these changes, the agglayer bridge test works fine with the most recent op-succinct kurtosis-cdk version.

As such, I think this is ready to land, so that we can use main to run test anytime now 🎉 