### PR TITLE
chore(agglayer): allow to customize tx receipt timeout

### DIFF
--- a/tests/agglayer/bridges.bats
+++ b/tests/agglayer/bridges.bats
@@ -17,7 +17,7 @@ setup() {
     network_id=$(cast call  --rpc-url "$l2_rpc_url" "$l2_bridge_addr" 'networkID()(uint32)')
     claimtxmanager_addr=${CLAIMTXMANAGER_ADDR:-"0x5f5dB0D4D58310F53713eF4Df80ba6717868A9f8"}
     claim_wait_duration=${CLAIM_WAIT_DURATION:-"10m"}
-    tx_receipt_timeout=${TX_RECEIPT_TIMEOUT:-"1m"}
+    tx_receipt_timeout_seconds=${TX_RECEIPT_TIMEOUT_SECONDS:-"60"}
 
     agglayer_rpc_url=${AGGLAYER_RPC_URL:-"$(kurtosis port print "$kurtosis_enclave_name" agglayer aglr-readrpc)"}
 
@@ -58,7 +58,7 @@ function fund_claim_tx_manager() {
             --private-key "$l1_private_key" \
             --rpc-url "$l1_rpc_url" \
             --value "$bridge_amount" \
-            --transaction-receipt-timeout "$tx_receipt_timeout"
+            --transaction-receipt-timeout "$tx_receipt_timeout_seconds"
 
     set +e
     polycli ulxly claim asset \
@@ -69,7 +69,7 @@ function fund_claim_tx_manager() {
             --deposit-network "0" \
             --bridge-service-url "$bridge_service_url" \
             --wait "$claim_wait_duration" \
-            --transaction-receipt-timeout "$tx_receipt_timeout"
+            --transaction-receipt-timeout "$tx_receipt_timeout_seconds"
     set -e
 
     final_l2_balance=$(cast balance --rpc-url "$l2_rpc_url" "$l2_eth_address")
@@ -98,7 +98,7 @@ function fund_claim_tx_manager() {
             --rpc-url "$l2_rpc_url" \
             --value "$bridge_amount" \
             --token-address "$weth_address" \
-            --transaction-receipt-timeout "$tx_receipt_timeout"
+            --transaction-receipt-timeout "$tx_receipt_timeout_seconds"
 
     tmp_file=$(mktemp)
     cast rpc --rpc-url "$agglayer_rpc_url" interop_getLatestPendingCertificateHeader "$network_id" > "$tmp_file"
@@ -111,7 +111,7 @@ function fund_claim_tx_manager() {
             --deposit-network "$network_id" \
             --bridge-service-url "$bridge_service_url" \
             --wait "$claim_wait_duration" \
-            --transaction-receipt-timeout "$tx_receipt_timeout"
+            --transaction-receipt-timeout "$tx_receipt_timeout_seconds"
 
     final_l1_balance=$(cast balance --rpc-url "$l1_rpc_url" "$l1_eth_address")
     if [[ $initial_l1_balance == "$final_l1_balance" ]]; then
@@ -157,7 +157,7 @@ function fund_claim_tx_manager() {
             --rpc-url "$l2_rpc_url" \
             --value "100" \
             --token-address "$erc20_addr" \
-            --transaction-receipt-timeout "$tx_receipt_timeout"
+            --transaction-receipt-timeout "$tx_receipt_timeout_seconds"
 
     polycli ulxly claim asset \
             --bridge-address "$l1_bridge_addr" \
@@ -167,7 +167,7 @@ function fund_claim_tx_manager() {
             --deposit-network "$network_id" \
             --bridge-service-url "$bridge_service_url" \
             --wait "$claim_wait_duration" \
-            --transaction-receipt-timeout "$tx_receipt_timeout"
+            --transaction-receipt-timeout "$tx_receipt_timeout_seconds"
 }
 
 # bats test_tags=smoke,rpc

--- a/tests/agglayer/bridges.bats
+++ b/tests/agglayer/bridges.bats
@@ -17,6 +17,7 @@ setup() {
     network_id=$(cast call  --rpc-url "$l2_rpc_url" "$l2_bridge_addr" 'networkID()(uint32)')
     claimtxmanager_addr=${CLAIMTXMANAGER_ADDR:-"0x5f5dB0D4D58310F53713eF4Df80ba6717868A9f8"}
     claim_wait_duration=${CLAIM_WAIT_DURATION:-"10m"}
+    tx_receipt_timeout=${TX_RECEIPT_TIMEOUT:-"1m"}
 
     agglayer_rpc_url=${AGGLAYER_RPC_URL:-"$(kurtosis port print "$kurtosis_enclave_name" agglayer aglr-readrpc)"}
 
@@ -56,7 +57,8 @@ function fund_claim_tx_manager() {
             --destination-network "$network_id" \
             --private-key "$l1_private_key" \
             --rpc-url "$l1_rpc_url" \
-            --value "$bridge_amount"
+            --value "$bridge_amount" \
+            --transaction-receipt-timeout "$tx_receipt_timeout"
 
     set +e
     polycli ulxly claim asset \
@@ -66,7 +68,8 @@ function fund_claim_tx_manager() {
             --deposit-count "$initial_deposit_count" \
             --deposit-network "0" \
             --bridge-service-url "$bridge_service_url" \
-            --wait "$claim_wait_duration"
+            --wait "$claim_wait_duration" \
+            --transaction-receipt-timeout "$tx_receipt_timeout"
     set -e
 
     final_l2_balance=$(cast balance --rpc-url "$l2_rpc_url" "$l2_eth_address")
@@ -94,7 +97,8 @@ function fund_claim_tx_manager() {
             --private-key "$l2_private_key" \
             --rpc-url "$l2_rpc_url" \
             --value "$bridge_amount" \
-            --token-address "$weth_address"
+            --token-address "$weth_address" \
+            --transaction-receipt-timeout "$tx_receipt_timeout"
 
     tmp_file=$(mktemp)
     cast rpc --rpc-url "$agglayer_rpc_url" interop_getLatestPendingCertificateHeader "$network_id" > "$tmp_file"
@@ -106,7 +110,8 @@ function fund_claim_tx_manager() {
             --deposit-count "$initial_deposit_count" \
             --deposit-network "$network_id" \
             --bridge-service-url "$bridge_service_url" \
-            --wait "$claim_wait_duration"
+            --wait "$claim_wait_duration" \
+            --transaction-receipt-timeout "$tx_receipt_timeout"
 
     final_l1_balance=$(cast balance --rpc-url "$l1_rpc_url" "$l1_eth_address")
     if [[ $initial_l1_balance == "$final_l1_balance" ]]; then
@@ -151,7 +156,8 @@ function fund_claim_tx_manager() {
             --private-key "$l2_private_key" \
             --rpc-url "$l2_rpc_url" \
             --value "100" \
-            --token-address "$erc20_addr"
+            --token-address "$erc20_addr" \
+            --transaction-receipt-timeout "$tx_receipt_timeout"
 
     polycli ulxly claim asset \
             --bridge-address "$l1_bridge_addr" \
@@ -160,7 +166,8 @@ function fund_claim_tx_manager() {
             --deposit-count "$initial_deposit_count" \
             --deposit-network "$network_id" \
             --bridge-service-url "$bridge_service_url" \
-            --wait "$claim_wait_duration"
+            --wait "$claim_wait_duration" \
+            --transaction-receipt-timeout "$tx_receipt_timeout"
 }
 
 # bats test_tags=smoke,rpc


### PR DESCRIPTION
Some of the bridge tests failed in CI because the tx receipt timeout was too short (60s).

<img width="1478" alt="Screenshot 2025-04-29 at 17 12 59" src="https://github.com/user-attachments/assets/234eb341-9e9e-416f-9119-58da7f220830" />

https://github.com/0xPolygon/kurtosis-cdk/actions/runs/14732425366/job/41349851730?pr=590
