### PR TITLE
feat: automatically build and push docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,8 @@
 # Ignore everything.
-**
+*
 
 !core/
 !lib/
+!scenarios/
 !tests/
 !foundry.toml

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,10 @@ on:
         type: string
         required: false
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,49 @@
+name: docker
+
+on:
+  # Trigger the workflow on pull requests made to the main branch.
+  # But avoid creating new images when changes only affect .github files.
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - ".github/**"
+
+  # Allow manual triggering of the workflow.
+  workflow_dispatch:
+    inputs:
+      checkout_ref:
+        description: The branch, commit or tag to checkout
+        type: string
+        required: false
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        base_image:
+          - cdk
+          - pos
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Get short commit id
+        run: |
+          short_commit_id=$(git rev-parse --short HEAD)
+          echo "SHORT_COMMIT_ID=${short_commit_id}" >> "${GITHUB_ENV}"
+          echo "SHORT_COMMIT_ID=${short_commit_id}" # debug
+
+      - name: Build and push image
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
+        with:
+          tags: ${{ env.DOCKER_USERNAME }}/test-runner:${{ env.SHORT_COMMIT_ID }}-${{ matrix.base_image }}
+          build-args: |
+            BASE_IMAGE=${{ matrix.base_image }}
+          push: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build and push image
         uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
         with:
-          tags: ${{ vars.DOCKER_USERNAME }}/test-runner:${{ env.SHORT_COMMIT_ID }}-${{ matrix.base_image }}
+          tags: ${{ vars.DOCKER_USERNAME }}/e2e:${{ env.SHORT_COMMIT_ID }}-${{ matrix.base_image }}
           build-args: |
             BASE_IMAGE=${{ matrix.base_image }}
           push: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
       - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
-          username: ${{ env.DOCKER_USERNAME }}
+          username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Get short commit id
@@ -43,7 +43,7 @@ jobs:
       - name: Build and push image
         uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
         with:
-          tags: ${{ env.DOCKER_USERNAME }}/test-runner:${{ env.SHORT_COMMIT_ID }}-${{ matrix.base_image }}
+          tags: ${{ vars.DOCKER_USERNAME }}/test-runner:${{ env.SHORT_COMMIT_ID }}-${{ matrix.base_image }}
           build-args: |
             BASE_IMAGE=${{ matrix.base_image }}
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,27 @@
+# Define the base image to use for the final image.
+# Options: "base", "cdk", "pos".
+ARG BASE_IMAGE="base"
+
+# STAGE 1: Build the polygon-cli binary.
 FROM golang:1.23-bookworm AS polycli-builder
-ENV POLYCLI_VERSION="v0.1.78"
 
 WORKDIR /opt/polygon-cli
+ARG POLYCLI_VERSION="v0.1.78"
 RUN apt-get update --yes \
   && git clone --branch ${POLYCLI_VERSION} https://github.com/maticnetwork/polygon-cli.git . \
   && make build
 
 
-FROM debian:bookworm-slim
-ENV FOUNDRY_VERSION="stable"
-ENV ANTITHESIS_TESTS_PATH=""
+# STAGE 2: Build the base image containing e2e tests.
+FROM debian:bookworm-slim AS base
 
 COPY --from=polycli-builder /opt/polygon-cli/out/polycli /usr/local/bin/polycli
 COPY --from=polycli-builder /opt/polygon-cli/bindings /opt/bindings
-COPY . .
 
 WORKDIR /opt/e2e
+COPY . .
+
+ARG FOUNDRY_VERSION="stable"
 RUN apt-get update --yes \
   && apt-get install --yes bats curl git jq python3-pip \
   # Install foundry.
@@ -24,9 +30,20 @@ RUN apt-get update --yes \
   && cp -r /root/.foundry/bin/* /usr/local/bin \
   # Install yq.
   && pip3 install --break-system-packages yq \
-  # If ANTITHESIS_TESTS_PATH is specified, copy test files to the correct location so that
-  # antithesis test composer can find them.
-  && if [[ -n "${ANTITHESIS_TESTS_PATH}" ]]; then \
-  mkdir -p /opt/antithesis/test/v1; \
-  cp -r ${ANTITHESIS_TESTS_PATH}/* /opt/antithesis/test/v1; \
-  fi
+  # Create folder for antithesis tests.
+  && mkdir -p /opt/antithesis/test/v1
+
+
+# STAGE 3.1: Build a cdk base image including e2e tests as well as antithesis cdk tests.
+FROM base AS cdk
+RUN mv tests/antithesis/cdk /opt/antithesis/test/v1/
+
+
+# STAGE 3.2: Build a pos base image including e2e tests as well as antithesis pos tests.
+FROM base AS pos
+WORKDIR /opt/e2e
+RUN mv tests/antithesis/pos /opt/antithesis/test/v1/
+
+
+# STAGE 4: Build the final image based on the selected type.
+FROM ${BASE_IMAGE} AS final

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,11 @@ RUN apt-get update --yes \
 
 FROM debian:bookworm-slim
 ENV FOUNDRY_VERSION="stable"
+ENV ANTITHESIS_TESTS_PATH=""
 
 COPY --from=polycli-builder /opt/polygon-cli/out/polycli /usr/local/bin/polycli
 COPY --from=polycli-builder /opt/polygon-cli/bindings /opt/bindings
+COPY . .
 
 WORKDIR /opt/e2e
 RUN apt-get update --yes \
@@ -22,8 +24,9 @@ RUN apt-get update --yes \
   && cp -r /root/.foundry/bin/* /usr/local/bin \
   # Install yq.
   && pip3 install --break-system-packages yq \
-  # Create folder for antithesis tests.
-  && mkdir -p /opt/antithesis/test/v1
-
-COPY . .
-COPY ./tests/antithesis/ /opt/antithesis/test/v1
+  # If ANTITHESIS_TESTS_PATH is specified, copy test files to the correct location so that
+  # antithesis test composer can find them.
+  && if [[ -n "${ANTITHESIS_TESTS_PATH}" ]]; then \
+  mkdir -p /opt/antithesis/test/v1; \
+  cp -r ${ANTITHESIS_TESTS_PATH}/* /opt/antithesis/test/v1; \
+  fi

--- a/tests/antithesis/cdk/anytime_read_block_number.sh
+++ b/tests/antithesis/cdk/anytime_read_block_number.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Script timeout duration, in seconds.
+timeout_seconds=30
+
+# Retry loop to avoid issues with network partitions.
+start_time=$(date +%s)
+end_time=$((start_time + timeout_seconds))
+while (($(date +%s) < end_time)); do
+  if cast block-number --rpc-url "${L2_RPC_URL}"; then
+    exit 0
+  fi
+  sleep 5
+done
+
+echo "Script failed after ${timeout_seconds} seconds. Exiting."
+exit 1


### PR DESCRIPTION
## Description

Automatically build and push docker images to the Docker hub when PRs get merged into `main`.

Two images will be pushed:
  - `leovct/e2e:<short_commit-id>-pos`: image containing e2e tests as well as antithesis pos tests.
  - `leovct/e2e:<short_commit-id>-cdk`: image containing e2e tests as well as antithesis cdk tests.

This can be achieved thanks to the `BASE_IMAGE` build arg which defines the base image to use for the final image.

It is also possible to build a base image without any antithesis tests using `docker build -t e2e .`