### PR TITLE
fix: `legacy-token-migrations` api response

### DIFF
--- a/core/helpers/scripts/aggkit_bridge_service.bash
+++ b/core/helpers/scripts/aggkit_bridge_service.bash
@@ -723,6 +723,15 @@ function get_legacy_token_migrations() {
             continue
         fi
 
+        count=$(echo "$legacy_token_migrations" | jq -r '.count')
+        log "ℹ️ Parsed count = $count"
+        # If count is still 0, sleep and retry
+        if (( count < 1 )); then
+            log "🔄 count is $count (<1), retrying in ${poll_frequency}s..."
+            sleep "$poll_frequency"
+            continue
+        fi
+
         echo "$legacy_token_migrations"
         return 0
     done


### PR DESCRIPTION
check `count` value in `legacy-token-migrations` api response.
If it is zero than we need to query again.