### PR TITLE
feat: remove l2 funding logic

### DIFF
--- a/.github/workflows/aggkit-e2e-multi-chains.yml
+++ b/.github/workflows/aggkit-e2e-multi-chains.yml
@@ -158,7 +158,6 @@ jobs:
           export BATS_LIB_PATH="$PWD/core/helpers/lib"
           export PROJECT_ROOT="$PWD"
           export ENCLAVE="${{ inputs.kurtosis-cdk-enclave-name }}"
-          export DISABLE_L2_FUND="true"
           chmod +x "/tmp/${{ inputs.aggsender-find-imported-bridge-artifact }}"
           export AGGSENDER_IMPORTED_BRIDGE_PATH="/tmp/${{ inputs.aggsender-find-imported-bridge-artifact }}"
           bats ./tests/aggkit/bridge-e2e-2-l2s.bats

--- a/.github/workflows/aggkit-e2e-single-chain.yml
+++ b/.github/workflows/aggkit-e2e-single-chain.yml
@@ -119,10 +119,8 @@ jobs:
           export PROJECT_ROOT="$PWD"
           export ENCLAVE="${{ inputs.kurtosis-cdk-enclave-name }}"
           if [[ $ENCLAVE == "op" ]]; then
-            export DISABLE_L2_FUND="false"
             bats ./tests/aggkit/bridge-e2e.bats ./tests/aggkit/e2e-pp.bats ./tests/aggkit/bridge-sovereign-chain-e2e.bats
           else
-            export DISABLE_L2_FUND="true"
             bats ./tests/aggkit/bridge-e2e-custom-gas.bats ./tests/aggkit/bridge-e2e.bats ./tests/aggkit/e2e-pp.bats
           fi
           popd

--- a/.github/workflows/cdk-e2e-multi-chains.yml
+++ b/.github/workflows/cdk-e2e-multi-chains.yml
@@ -134,7 +134,6 @@ jobs:
           export BATS_LIB_PATH="$PWD/core/helpers/lib"
           export PROJECT_ROOT="$PWD"
           export ENCLAVE="${{ inputs.kurtosis-cdk-enclave-name }}"
-          export DISABLE_L2_FUND="true"
           bats ./tests/aggkit/bridge-e2e-2-l2s.bats
           popd
 

--- a/.github/workflows/cdk-e2e.yml
+++ b/.github/workflows/cdk-e2e.yml
@@ -133,7 +133,6 @@ jobs:
           export BATS_LIB_PATH="$PWD/core/helpers/lib"
           export PROJECT_ROOT="$PWD"
           export ENCLAVE="${{ inputs.kurtosis-cdk-enclave-name }}"
-          export DISABLE_L2_FUND="true"
           bats tests/cdk/access-list-e2e.bats tests/cdk/basic-e2e.bats
           if [[ "${{ inputs.test-name }}" == "test-fork9-cdk-validium-e2e" || "${{ inputs.test-name }}" == "test-fork11-rollup-e2e" || "${{ inputs.test-name }}" == "test-fork12-rollup-e2e-zkevm-bridge" ]]; then
             bats tests/cdk/e2e.bats tests/cdk/bridge-e2e.bats

--- a/core/helpers/agglayer-cdk-common-setup.bash
+++ b/core/helpers/agglayer-cdk-common-setup.bash
@@ -140,40 +140,6 @@ _agglayer_cdk_common_setup() {
     readonly is_forced=${IS_FORCED:-"true"}
     meta_bytes=${META_BYTES:-"0x1234"}
 
-    if [[ -z "${DISABLE_L2_FUND}" || "${DISABLE_L2_FUND}" == "false" ]]; then
-        readonly test_account_key=${SENDER_PRIVATE_KEY:-"12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625"}
-        readonly test_account_addr="$(cast wallet address --private-key $test_account_key)"
-
-        local token_balance
-        token_balance=$(cast balance --rpc-url "$L2_RPC_URL" "$test_account_addr" 2>/dev/null)
-        if [ $? -ne 0 ]; then
-            echo "⚠️ Failed to fetch token balance for $test_account_addr on $L2_RPC_URL" >&2
-            token_balance=0
-        fi
-
-        # Threshold: 0.1 ether in wei
-        local threshold=100000000000000000
-
-        # Only fund if balance is less than or equal to 0.1 ether
-        # (it's a real big number, so we compare the length of strings)
-        if [[ ${#token_balance} -le ${#threshold} ]]; then
-            local l2_coinbase_key=${L2_COINBASE_KEY:-"ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"}
-            local amt="10ether"
-
-            echo "💸 $test_account_addr L2 balance ($token_balance) is low (≤ 0.1 ETH), funding with amt=$amt..." >&3
-            fund "$l2_coinbase_key" "$test_account_addr" "$amt" "$L2_RPC_URL"
-            if [ $? -ne 0 ]; then
-                echo "❌ Funding L2 receiver $test_account_addr failed" >&2
-                return 1
-            fi
-            echo "✅ Successfully funded $test_account_addr with $amt on L2" >&3
-        else
-            echo "✅ Receiver $test_account_addr already has $(cast --from-wei "$token_balance") ETH on L2" >&3
-        fi
-    else
-        echo "🚫 Skipping L2 funding since DISABLE_L2_FUND is set to true" >&3
-    fi
-
     local combined_json_file="/opt/zkevm/combined.json"
     kurtosis_download_file_exec_method $ENCLAVE $CONTRACTS_CONTAINER "$combined_json_file" | jq '.' >combined.json
     local combined_json_output=$(cat combined.json)


### PR DESCRIPTION
The PR removes `DISABLE_L2_FUND` and L2 funding logic, since the L2 accounts are pre-funded in the kurtosis cdk.