### PR TITLE
fix: remove optimistic mode tests until they are working

### DIFF
--- a/.github/workflows/aggkit-e2e-single-chain.yml
+++ b/.github/workflows/aggkit-e2e-single-chain.yml
@@ -121,8 +121,7 @@ jobs:
           if [[ $ENCLAVE == "op" ]]; then
             bats ./tests/aggkit/bridge-e2e.bats \
                  ./tests/aggkit/e2e-pp.bats \
-                 ./tests/aggkit/bridge-sovereign-chain-e2e.bats \
-                 ./tests/op/optimistic-mode.bats
+                 ./tests/aggkit/bridge-sovereign-chain-e2e.bats
           else
             bats ./tests/aggkit/bridge-e2e.bats \
                  ./tests/aggkit/e2e-pp.bats \


### PR DESCRIPTION
Optimistic mode E2E tests are failing currently, so removing them from execution until they are working.