### PR TITLE
ci(datadog): record e2e test run on datadog with ai report

### DIFF
--- a/.github/workflows/aggkit-e2e-multi-chains.yml
+++ b/.github/workflows/aggkit-e2e-multi-chains.yml
@@ -193,6 +193,7 @@ jobs:
 
       - name: Record test run in Datadog
         if: always()
+        continue-on-error: true
         uses: agglayer/gha-record-e2e-test-run@v1
         with:
           enable_ai_analysis: "true"

--- a/.github/workflows/aggkit-e2e-multi-chains.yml
+++ b/.github/workflows/aggkit-e2e-multi-chains.yml
@@ -170,14 +170,14 @@ jobs:
       - name: Dump enclave logs
         if: ${{ failure() }}
         run: kurtosis dump ./dump
-    
+
       - name: Generate archive name
         if: ${{ failure() }}
         run: |
           archive_name="dump_run_with_args_${{ inputs.number-of-chains}}_${{ github.run_id }}"
           echo "ARCHIVE_NAME=${archive_name}" >> "$GITHUB_ENV"
           echo "Generated archive name: ${archive_name}"
-  
+
       - name: Upload logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
@@ -190,3 +190,16 @@ jobs:
         run: |
           kurtosis enclave stop '${{ inputs.kurtosis-cdk-enclave-name }}'
           kurtosis clean
+
+      - name: Record test run in Datadog
+        if: always()
+        uses: agglayer/gha-record-e2e-test-run@v1
+        with:
+          enable_ai_analysis: "true"
+          host: "github-actions-runners"
+          status: ${{ job.status }}
+          ref_kurtosis: "${{ inputs.kurtosis-cdk-ref }}"
+          ref_e2e: "${{ inputs.agglayer-e2e-ref }}"
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/aggkit-e2e-single-chain.yml
+++ b/.github/workflows/aggkit-e2e-single-chain.yml
@@ -158,6 +158,7 @@ jobs:
 
       - name: Record test run in Datadog
         if: always()
+        continue-on-error: true
         uses: agglayer/gha-record-e2e-test-run@v1
         with:
           enable_ai_analysis: "true"

--- a/.github/workflows/aggkit-e2e-single-chain.yml
+++ b/.github/workflows/aggkit-e2e-single-chain.yml
@@ -135,14 +135,14 @@ jobs:
       - name: Dump enclave logs
         if: ${{ failure() }}
         run: kurtosis dump ./dump
-    
+
       - name: Generate archive name
         if: ${{ failure() }}
         run: |
           archive_name="dump_run_with_args_${{inputs.test-name}}_${{ github.run_id }}"
           echo "ARCHIVE_NAME=${archive_name}" >> "$GITHUB_ENV"
           echo "Generated archive name: ${archive_name}"
-  
+
       - name: Upload logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
@@ -155,3 +155,16 @@ jobs:
         run: |
           kurtosis enclave stop '${{ inputs.kurtosis-cdk-enclave-name }}'
           kurtosis clean
+
+      - name: Record test run in Datadog
+        if: always()
+        uses: agglayer/gha-record-e2e-test-run@v1
+        with:
+          enable_ai_analysis: "true"
+          host: "github-actions-runners"
+          status: ${{ job.status }}
+          ref_kurtosis: "${{ inputs.kurtosis-cdk-ref }}"
+          ref_e2e: "${{ inputs.agglayer-e2e-ref }}"
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/agglayer-e2e.yml
+++ b/.github/workflows/agglayer-e2e.yml
@@ -186,3 +186,17 @@ jobs:
         run: |
           kurtosis enclave stop '${{ inputs.kurtosis-cdk-enclave-name }}'
           kurtosis clean
+
+      - name: Record test run in Datadog
+        if: always()
+        uses: agglayer/gha-record-e2e-test-run@v1
+        with:
+          enable_ai_analysis: "true"
+          host: "github-actions-runners"
+          status: ${{ job.status }}
+          ref_agglayer: "${{ inputs.docker-image-override == 'agglayer_image' && inputs.docker-tag || '' }}"
+          ref_kurtosis: "${{ inputs.kurtosis-cdk-ref }}"
+          ref_e2e: "${{ inputs.agglayer-e2e-ref }}"
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/agglayer-e2e.yml
+++ b/.github/workflows/agglayer-e2e.yml
@@ -189,6 +189,7 @@ jobs:
 
       - name: Record test run in Datadog
         if: always()
+        continue-on-error: true
         uses: agglayer/gha-record-e2e-test-run@v1
         with:
           enable_ai_analysis: "true"

--- a/.github/workflows/cdk-e2e-multi-chains.yml
+++ b/.github/workflows/cdk-e2e-multi-chains.yml
@@ -140,14 +140,14 @@ jobs:
       - name: Dump enclave logs
         if: ${{ failure() }}
         run: kurtosis dump ./dump
-    
+
       - name: Generate archive name
         if: ${{ failure() }}
         run: |
           archive_name="dump_run_with_args_${{ github.run_id }}"
           echo "ARCHIVE_NAME=${archive_name}" >> "$GITHUB_ENV"
           echo "Generated archive name: ${archive_name}"
-  
+
       - name: Upload logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
@@ -160,3 +160,17 @@ jobs:
         run: |
           kurtosis enclave stop '${{ inputs.kurtosis-cdk-enclave-name }}'
           kurtosis clean
+
+      - name: Record test run in Datadog
+        if: always()
+        uses: agglayer/gha-record-e2e-test-run@v1
+        with:
+          enable_ai_analysis: "true"
+          host: "github-actions-runners"
+          status: ${{ job.status }}
+          ref_agglayer: "${{ inputs.docker-image-override == 'agglayer_image' && inputs.docker-tag || '' }}"
+          ref_kurtosis: "${{ inputs.kurtosis-cdk-ref }}"
+          ref_e2e: "${{ inputs.agglayer-e2e-ref }}"
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/cdk-e2e-multi-chains.yml
+++ b/.github/workflows/cdk-e2e-multi-chains.yml
@@ -163,6 +163,7 @@ jobs:
 
       - name: Record test run in Datadog
         if: always()
+        continue-on-error: true
         uses: agglayer/gha-record-e2e-test-run@v1
         with:
           enable_ai_analysis: "true"

--- a/.github/workflows/cdk-e2e.yml
+++ b/.github/workflows/cdk-e2e.yml
@@ -146,14 +146,14 @@ jobs:
       - name: Dump enclave logs
         if: ${{ failure() }}
         run: kurtosis dump ./dump
-    
+
       - name: Generate archive name
         if: ${{ failure() }}
         run: |
           archive_name="dump_run_with_args_${{ inputs.test-name}}_${{ github.run_id }}"
           echo "ARCHIVE_NAME=${archive_name}" >> "$GITHUB_ENV"
           echo "Generated archive name: ${archive_name}"
-  
+
       - name: Upload logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
@@ -166,3 +166,17 @@ jobs:
         run: |
           kurtosis enclave stop '${{ inputs.kurtosis-cdk-enclave-name }}'
           kurtosis clean
+
+      - name: Record test run in Datadog
+        if: always()
+        uses: agglayer/gha-record-e2e-test-run@v1
+        with:
+          enable_ai_analysis: "true"
+          host: "github-actions-runners"
+          status: ${{ job.status }}
+          ref_agglayer: "${{ inputs.docker-image-override == 'agglayer_image' && inputs.docker-tag || '' }}"
+          ref_kurtosis: "${{ inputs.kurtosis-cdk-ref }}"
+          ref_e2e: "${{ inputs.agglayer-e2e-ref }}"
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/cdk-e2e.yml
+++ b/.github/workflows/cdk-e2e.yml
@@ -169,6 +169,7 @@ jobs:
 
       - name: Record test run in Datadog
         if: always()
+        continue-on-error: true
         uses: agglayer/gha-record-e2e-test-run@v1
         with:
           enable_ai_analysis: "true"


### PR DESCRIPTION
This PR makes use of the `agglayer/gha-record-e2e-test-run` action to record the e2e test runs on datadog with a failure (if failed) analysis with chatGPT.