### PR TITLE
test: add shellcheck into ci

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run ShellCheck on changed files
         run: |
-            CHANGED_FILES=$(git diff --name-only --diff-filter=AM HEAD^ HEAD | grep -E '\.(sh|bash)$' || true)
+            CHANGED_FILES=$(git diff --name-only --diff-filter=AM HEAD^ HEAD | grep -E '\.(sh|bash|bats)$' || true)
             if [[ -n "$CHANGED_FILES" ]]; then
             echo "Checking files: $CHANGED_FILES"
             echo "$CHANGED_FILES" | xargs -r shellcheck -s bash -S warning


### PR DESCRIPTION
# Description

- Add shellcheck into github actions
    - Checks for files with `sh|bash|bats` extensions
- Checks only for `git diff` with current HEAD commit, so existing files are not checked