### PR TITLE
Fix command to fetch state sync events from hv2

### DIFF
--- a/tests/pos/bridge.bats
+++ b/tests/pos/bridge.bats
@@ -10,7 +10,7 @@ setup() {
   if [[ "${L2_CL_NODE_TYPE}" == "heimdall" ]]; then
     HEIMDALL_STATE_SYNC_COUNT_CMD='curl --silent "${L2_CL_API_URL}/clerk/event-record/list" | jq ".result | length"'
   elif [[ "${L2_CL_NODE_TYPE}" == "heimdall-v2" ]]; then
-    HEIMDALL_STATE_SYNC_COUNT_CMD='curl --silent "${L2_CL_API_URL}/clerk/event-records/list" | jq ".event_records | length"'
+    HEIMDALL_STATE_SYNC_COUNT_CMD='curl --silent "${L2_CL_API_URL}/clerk/event-records/list?page=1&limit=50" | jq ".event_records | length"'
   fi
   BOR_STATE_SYNC_COUNT_CMD='cast call --rpc-url "${L2_RPC_URL}" "${L2_STATE_RECEIVER_ADDRESS}" "lastStateId()(uint)"'
 


### PR DESCRIPTION
A recent change in heimdall v2 requires the query to contain page number and limit. 

Tested locally in a kurtosis devnet with latest version of hv2

```
➜  ~/src curl -s "$(kurtosis port print pos-devnet l2-cl-1-heimdall-v2-bor-validator http)/clerk/event-records/list" | jq ".event_records | length"
0
➜  ~/src curl -s "$(kurtosis port print pos-devnet l2-cl-1-heimdall-v2-bor-validator http)/clerk/event-records/list?page=1&limit=50" | jq ".event_records | length"
1
```