### PR TITLE
docs: monitored-tests docs

### DIFF
--- a/scenarios/chaos-test/config-chaos.bash
+++ b/scenarios/chaos-test/config-chaos.bash
@@ -1,0 +1,171 @@
+#!/bin/bash
+
+###############################################################################
+# config-chaos.bash
+#
+# This script performs configuration fuzz testing on the agglayer container.
+# It randomly modifies selected fields in the agglayer TOML config file,
+# copies the fuzzed config into the running container, and restarts it.
+#
+# Steps:
+# 1. Checks if the agglayer container is running.
+# 2. Copies the current config file from the container to a log directory.
+# 3. Randomly fuzzes timeouts, intervals, buffer sizes, ports, booleans, etc.
+#    - Some fields are always fuzzed, others are fuzzed with a probability.
+# 4. Copies the fuzzed config back into the container.
+# 5. Restarts the container to apply the new configuration.
+#
+# Usage:
+#   bash config-chaos.bash
+#
+# Output:
+#   - All configs and logs are saved in a timestamped directory under $PWD.
+#   - The agglayer container will be restarted with the fuzzed configuration.
+###############################################################################
+
+is_container_running() {
+    local container_id="$1"
+    docker ps --format '{{.ID}}' | grep -qw "$container_id"
+}
+
+if ! is_container_running "$agglayer_container_uuid"; then
+    echo "Error: Container $agglayer_container_uuid is not running."
+    exit 1
+fi
+
+# Set ROOT_DIR to current working directory if not already set
+LOG_ROOT_DIR="${LOG_ROOT_DIR:-$PWD}"
+
+# Create main log directory
+LOG_DIR="${LOG_ROOT_DIR}/config_chaos_$(date +%Y%m%d_%H%M%S)"
+mkdir -p "$LOG_DIR"
+
+# Configuration: Single probability for fuzzing any parameter (0.0 to 1.0)
+FUZZ_PROB=0.05  # 5% chance to fuzz each parameter
+
+# Get agglayer configs
+agglayer_container_uuid=$(docker ps --format '{{.Names}} {{.ID}}' --no-trunc | grep "agglayer--" | awk '{print $2}')
+docker cp $agglayer_container_uuid:/etc/zkevm/agglayer-config.toml $LOG_DIR/initial-agglayer-config.toml
+
+# Helper functions to generate random values
+_rand_int() {
+    local min=$1
+    local max=$2
+    echo $((RANDOM % (max - min + 1) + min))
+}
+
+_rand_float() {
+    local min=$1
+    local max=$2
+    local scale=$3
+    local range=$(echo "($max - $min) * $scale" | bc)
+    local random_val=$(echo "$min * $scale + ($RANDOM % $range)" | bc)
+    echo "scale=$scale; $random_val / $scale" | bc
+}
+
+_rand_bool() {
+    if [[ $((RANDOM % 2)) -eq 0 ]]; then
+        echo "true"
+    else
+        echo "false"
+    fi
+}
+
+# Function to decide whether to fuzz a parameter based on FUZZ_PROB
+_should_fuzz() {
+    local prob_int=$(echo "$FUZZ_PROB * 100" | bc | cut -d. -f1)
+    [[ -z "$prob_int" ]] && prob_int=0
+    local rand=$((RANDOM % 100))
+    if [[ $rand -lt $prob_int ]]; then
+        return 0  # Fuzz the parameter
+    else
+        return 1  # Don't fuzz the parameter
+    fi
+}
+
+# Function to fuzz a TOML configuration file by modifying sensible fields
+# Generates a large number of unique configurations using randomization
+_generate_fuzzed_agglayer_configs() {
+    # Input and output files
+    INPUT_FILE="$LOG_DIR/initial-agglayer-config.toml"
+    OUTPUT_FILE="$LOG_DIR/fuzzed-agglayer-config.toml"
+
+    # Check if input file exists
+    if [[ ! -f "$INPUT_FILE" ]]; then
+        echo "Error: Input file $INPUT_FILE not found"
+        exit 1
+    fi
+
+    # Read the input TOML file
+    cp "$INPUT_FILE" "$OUTPUT_FILE"
+
+    # =============================================================================
+    # Parameters to always fuzz
+    # =============================================================================
+    # Timeouts and intervals
+    sed -i "s/request-timeout = 180/request-timeout = $(_rand_int 60 300)/" "$OUTPUT_FILE"
+    sed -i "s/settlement-timeout = 1200/settlement-timeout = $(_rand_int 600 1800)/" "$OUTPUT_FILE"
+    sed -i "s/retry-interval = 7/retry-interval = $(_rand_int 5 15)/" "$OUTPUT_FILE"
+    sed -i "s/rpc-timeout = 45/rpc-timeout = $(_rand_int 30 90)/" "$OUTPUT_FILE"
+    sed -i "s/runtime-timeout = 5/runtime-timeout = $(_rand_int 3 10)/" "$OUTPUT_FILE"
+
+    # Size limits
+    sed -i "s/max-request-body-size = 104857600/max-request-body-size = $(_rand_int 52428800 209715200)/" "$OUTPUT_FILE"
+    sed -i "s/max-decoding-message-size = 104857600/max-decoding-message-size = $(_rand_int 52428800 209715200)/" "$OUTPUT_FILE"
+
+    # Retry and gas settings
+    sed -i "s/max-retries = 3/max-retries = $(_rand_int 1 5)/" "$OUTPUT_FILE"
+    sed -i "s/gas-multiplier-factor = 175/gas-multiplier-factor = $(_rand_int 25 325)/" "$OUTPUT_FILE"
+
+    # Epoch duration
+    sed -i "s/epoch-duration = 15/epoch-duration = $(_rand_int 10 30)/" "$OUTPUT_FILE"
+
+    # Rate limiting (randomly enable/disable or set values)
+    if [[ $((RANDOM % 2)) -eq 0 ]]; then
+        sed -i "s/send-tx = \"unlimited\"/# send-tx = \"limited\"/" "$OUTPUT_FILE"
+        sed -i "s/# \[rate-limiting.send-tx\]/[rate-limiting.send-tx]/" "$OUTPUT_FILE"
+        sed -i "s/# max-per-interval = 1/max-per-interval = $(_rand_int 1 5)/" "$OUTPUT_FILE"
+        sed -i "s/# time-interval = \"15m\"/time-interval = \"$(_rand_int 0 30)m\"/" "$OUTPUT_FILE"
+    else
+        sed -i "s/send-tx = \"unlimited\"/send-tx = \"unlimited\"/" "$OUTPUT_FILE"
+        sed -i "s/\[rate-limiting.send-tx\]/# [rate-limiting.send-tx]/" "$OUTPUT_FILE"
+    fi
+
+    # Buffer size
+    sed -i "s/input-backpressure-buffer-size = 1000/input-backpressure-buffer-size = $(_rand_int 25 2000)/" "$OUTPUT_FILE"
+
+    # Backup counts
+    sed -i "s/state-max-backup-count = 100/state-max-backup-count = $(_rand_int 5 225)/" "$OUTPUT_FILE"
+    sed -i "s/pending-max-backup-count = 100/pending-max-backup-count = $(_rand_int 5 225)/" "$OUTPUT_FILE"
+
+    # =============================================================================
+    # Parameters to fuzz probabilistically
+    # =============================================================================
+    # Ports (grpc-port, readrpc-port, admin-port, prometheus-addr port)
+    if _should_fuzz; then
+        sed -i "s/grpc-port = 4443/grpc-port = $(_rand_int 4443 4446)/" "$OUTPUT_FILE"
+    fi
+    if _should_fuzz; then
+        sed -i "s/readrpc-port = 4444/readrpc-port = $(_rand_int 4443 4446)/" "$OUTPUT_FILE"
+    fi
+    if _should_fuzz; then
+        sed -i "s/admin-port = 4446/admin-port = $(_rand_int 4443 4446)/" "$OUTPUT_FILE"
+    fi
+
+    # Boolean flags
+    if _should_fuzz; then
+        sed -i "s/mock-verifier = true/mock-verifier = $(_rand_bool)/" "$OUTPUT_FILE"
+    fi
+
+    echo "Generated fuzzed configuration: $OUTPUT_FILE"
+}
+
+# Call the function
+_generate_fuzzed_agglayer_configs
+
+# Replace the initial configs with fuzzed configs in the agglayer container
+docker cp $LOG_DIR/fuzzed-agglayer-config.toml $agglayer_container_uuid:/etc/zkevm/agglayer-config.toml
+
+# Restart the container
+docker stop $agglayer_container_uuid
+docker start $agglayer_container_uuid

--- a/scenarios/chaos-test/config-chaos.bash
+++ b/scenarios/chaos-test/config-chaos.bash
@@ -45,7 +45,7 @@ FUZZ_PROB=0.05  # 5% chance to fuzz each parameter
 
 # Get agglayer configs
 agglayer_container_uuid=$(docker ps --format '{{.Names}} {{.ID}}' --no-trunc | grep "agglayer--" | awk '{print $2}')
-docker cp $agglayer_container_uuid:/etc/zkevm/agglayer-config.toml $LOG_DIR/initial-agglayer-config.toml
+docker cp "$agglayer_container_uuid":/etc/zkevm/agglayer-config.toml "$LOG_DIR"/initial-agglayer-config.toml
 
 # Helper functions to generate random values
 _rand_int() {
@@ -58,8 +58,10 @@ _rand_float() {
     local min=$1
     local max=$2
     local scale=$3
-    local range=$(echo "($max - $min) * $scale" | bc)
-    local random_val=$(echo "$min * $scale + ($RANDOM % $range)" | bc)
+    local range
+    range=$(echo "($max - $min) * $scale" | bc)
+    local random_val
+    random_val=$(echo "$min * $scale + ($RANDOM % $range)" | bc)
     echo "scale=$scale; $random_val / $scale" | bc
 }
 
@@ -73,7 +75,8 @@ _rand_bool() {
 
 # Function to decide whether to fuzz a parameter based on FUZZ_PROB
 _should_fuzz() {
-    local prob_int=$(echo "$FUZZ_PROB * 100" | bc | cut -d. -f1)
+    local prob_int
+    prob_int=$(echo "$FUZZ_PROB * 100" | bc | cut -d. -f1)
     [[ -z "$prob_int" ]] && prob_int=0
     local rand=$((RANDOM % 100))
     if [[ $rand -lt $prob_int ]]; then
@@ -164,8 +167,8 @@ _generate_fuzzed_agglayer_configs() {
 _generate_fuzzed_agglayer_configs
 
 # Replace the initial configs with fuzzed configs in the agglayer container
-docker cp $LOG_DIR/fuzzed-agglayer-config.toml $agglayer_container_uuid:/etc/zkevm/agglayer-config.toml
+docker cp "$LOG_DIR"/fuzzed-agglayer-config.toml "$agglayer_container_uuid":/etc/zkevm/agglayer-config.toml
 
 # Restart the container
-docker stop $agglayer_container_uuid
-docker start $agglayer_container_uuid
+docker stop "$agglayer_container_uuid"
+docker start "$agglayer_container_uuid"

--- a/scenarios/chaos-test/network-chaos.bash
+++ b/scenarios/chaos-test/network-chaos.bash
@@ -135,7 +135,7 @@ while IFS= read -r test_case; do
     RATELIMIT_PID=$!
 
     # Adds packet duplication
-    pumba --log-level debug net:em \
+    pumba --log-level debug netem \
       --duration "$DURATION" \
       --interface eth0 \
       --tc-image "$NETTOOLS_IMAGE" \
@@ -157,8 +157,8 @@ while IFS= read -r test_case; do
     # Drop incoming packets
     pumba --log-level debug iptables \
       --duration "$DURATION" \
-      --protocol tcp \
-      --dst-port 80 \
+      --protocol any \
+      --dst-port 4443,4444,8545,8546,5567,5577,4445,4000,9000,8547,8548,8560 \
       --iptables-image "$NETTOOLS_IMAGE" \
       loss \
       --probability "$PROBABILITY" \

--- a/scenarios/chaos-test/network-chaos.bash
+++ b/scenarios/chaos-test/network-chaos.bash
@@ -66,7 +66,10 @@ echo "Valid containers: ${VALID_CONTAINERS[*]}" | tee -a "$LOG_DIR/test_paramete
 TEST_CASES=$(jq -c '.[]' "$MATRIX_FILE")
 TEST_INDEX=1
 
+PIDS=()  # Array to track background PIDs
+
 while IFS= read -r test_case; do
+  (
     # Create test-specific log directory
     TEST_LOG_DIR="$LOG_DIR/test_$TEST_INDEX"
     mkdir -p "$TEST_LOG_DIR"
@@ -80,21 +83,22 @@ while IFS= read -r test_case; do
 
     # Skip if container is not valid
     if ! echo "${VALID_CONTAINERS[@]}" | grep -qw "$CONTAINER"; then
-        echo "Skipping test case $TEST_INDEX: Container $CONTAINER is invalid or excluded" | tee -a "$TEST_LOG_DIR/test_parameters.log"
-        ((TEST_INDEX++))
-        continue
+        echo "Skipping test case $TEST_INDEX: Container $CONTAINER is invalid or excluded" >> "$TEST_LOG_DIR/test_parameters.log"
+        exit 0
     fi
 
-    echo "Running test case $TEST_INDEX" | tee -a "$TEST_LOG_DIR/test_parameters.log"
+    echo "Started test case $TEST_INDEX for container $CONTAINER"
 
-    # Log test parameters
-    echo "Test Case $TEST_INDEX Parameters:" | tee -a "$TEST_LOG_DIR/test_parameters.log"
-    echo "Container: $CONTAINER" | tee -a "$TEST_LOG_DIR/test_parameters.log"
-    echo "Duration: $DURATION" | tee -a "$TEST_LOG_DIR/test_parameters.log"
-    echo "Percent: $PERCENT%" | tee -a "$TEST_LOG_DIR/test_parameters.log"
-    echo "Probability: $PROBABILITY" | tee -a "$TEST_LOG_DIR/test_parameters.log"
-    echo "Rate: $RATE" | tee -a "$TEST_LOG_DIR/test_parameters.log"
-    echo "Jitter: $JITTER ms" | tee -a "$TEST_LOG_DIR/test_parameters.log"
+    # All detailed logs go to the test log file only
+    {
+      echo "Test Case $TEST_INDEX Parameters:"
+      echo "Container: $CONTAINER"
+      echo "Duration: $DURATION"
+      echo "Percent: $PERCENT%"
+      echo "Probability: $PROBABILITY"
+      echo "Rate: $RATE"
+      echo "Jitter: $JITTER ms"
+    } >> "$TEST_LOG_DIR/test_parameters.log"
 
     # Start collecting container logs in background
     docker logs "$CONTAINER" --follow > "$TEST_LOG_DIR/container_${CONTAINER}_logs.log" 2>&1 &
@@ -157,7 +161,7 @@ while IFS= read -r test_case; do
     # Drop incoming packets
     pumba --log-level debug iptables \
       --duration "$DURATION" \
-      --protocol any \
+      --protocol tcp \
       --dst-port 4443,4444,8545,8546,5567,5577,4445,4000,9000,8547,8548,8560 \
       --iptables-image "$NETTOOLS_IMAGE" \
       loss \
@@ -178,7 +182,14 @@ while IFS= read -r test_case; do
     wait $CONTAINER_LOG_PID 2>/dev/null
 
     echo "Test case $TEST_INDEX complete!" | tee -a "$TEST_LOG_DIR/test_parameters.log"
-    ((TEST_INDEX++))
+  ) &
+  PIDS+=($!)
+  ((TEST_INDEX++))
 done <<< "$TEST_CASES"
+
+# Wait for all parallel test cases to finish
+for pid in "${PIDS[@]}"; do
+    wait $pid
+done
 
 echo "Network chaos complete! Logs saved in $LOG_DIR"

--- a/scenarios/monitored-tests/README.md
+++ b/scenarios/monitored-tests/README.md
@@ -1,2 +1,47 @@
-# Description
-The purpose of this scenario is to template a test where we have a defined pre-state and post-state for running multiple E2E tests against a single Kurtosis CDK network.
+# Monitored Tests
+
+## Overview
+
+This directory contains a scenario template for running multiple E2E tests against a single Kurtosis CDK network, with well-defined pre-state and post-state (TODO) conditions. It is designed to orchestrate chaos and stress tests in parallel with E2E tests, enabling robust validation of network behavior under various conditions.
+
+## Structure
+
+- **monitored-tests.bats**: Main Bats test orchestrator that sets up the environment, parses input, and runs chaos, stress, and E2E tests in parallel.
+- **pre-state/**: Contains input templates and configuration files that define the initial state and test matrices.
+- **post-state/**: Directory where logs and outputs from the tests are stored. Automation and useful parsing of this needs to be done in the future.
+
+## How It Works
+
+1. **Setup**: The test orchestrator sets up environment variables, checks for the required Docker network, and parses the test input template to generate specific input files for chaos, stress, and E2E tests.
+2. **Parallel Execution**: 
+   - Runs chaos and stress tests in the background.
+   - Reads the list of E2E test files from the input and runs each in parallel, with configurable timeouts.
+3. **Monitoring & Cleanup**: Tracks all test process IDs for proper cleanup and handles interrupts gracefully.
+4. **Logging**: Redirects logs and results to the `post-state` directory for later analysis.
+
+## Usage
+
+From the root `e2e` directory, run:
+
+```sh
+bats ./scenarios/monitored-tests/monitored-tests.bats
+```
+
+### Environment Variables
+
+- `ENCLAVE_NAME`: Name of the Kurtosis enclave (default: `cdk`)
+- `L2_RPC_URL`: RPC URL for L2 node (auto-detected if not set)
+- `TEST_DURATION`: Duration for chaos/stress tests (default: `5s`)
+- `TEST_TIMEOUT`: Timeout for each E2E test (default: `300s`)
+- `LOG_ROOT_DIR`: Directory for logs (default: `./scenarios/monitored-tests/post-state`)
+
+## Input Configuration
+
+Edit `pre-state/test_input_template.json` to define:
+- Chaos test parameters
+- Stress test parameters
+- List of E2E test files to run
+
+## Notes
+
+- Ensure all referenced E2E test files exist and are executable, and compatible with the monitored-tests orchestrator.

--- a/scenarios/monitored-tests/README.md
+++ b/scenarios/monitored-tests/README.md
@@ -42,6 +42,18 @@ Edit `pre-state/test_input_template.json` to define:
 - Stress test parameters
 - List of E2E test files to run
 
+To automatically generate new valid stress and chaos test inputs, run `./pre-state/generate_test_input.bash` file.
+You will still have to manually fill out the E2E tests array to run.
+
+```
+  "e2e_tests": [
+    "./tests/execution/polycli-cases.bats",
+    "./tests/execution/conflicting-contract-calls.bats",
+    "./tests/execution/special-addresses.bats",
+    "./tests/execution/conflicting-transactions-to-pool.bats"
+  ],
+```
+
 ## Notes
 
 - Ensure all referenced E2E test files exist and are executable, and compatible with the monitored-tests orchestrator.

--- a/scenarios/monitored-tests/monitored-tests.bats
+++ b/scenarios/monitored-tests/monitored-tests.bats
@@ -68,6 +68,8 @@ _parse_pre_state_input() {
     # parse e2e-tests to run
     cat "./scenarios/monitored-tests/pre-state/test_input_template.json" | jq '."e2e_tests"' > "$TMP_DIR"/e2e_tests.json
     echo "e2e_tests to run created at: $TMP_DIR/e2e_tests.json" >&3 
+
+    echo "====================================================" >&3
 }
 
 @test "Run tests combinations" {

--- a/scenarios/monitored-tests/pre-state/generate_test_input.bash
+++ b/scenarios/monitored-tests/pre-state/generate_test_input.bash
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+TEST_INPUT_TEMPLATE="test_input_template.json"
+
+_generate_stress_test_input() {
+    # List of container names to exclude
+    EXCLUDE_CONTAINERS=("kurtosis-" "validator-key-generation-cl-validator-keystore" "test-runner" "contracts-001")
+
+    # Get list of running containers with names and IDs, excluding specified ones
+    CONTAINERS=()
+    CONTAINER_MAPPINGS=()
+
+    # Read docker ps output and process line by line
+    while IFS= read -r line; do
+        if [[ -n "$line" ]]; then
+            CONTAINER_NAME=$(echo "$line" | awk '{print $1}')
+            CONTAINER_ID=$(echo "$line" | awk '{print $2}')
+            
+            # Add to arrays
+            CONTAINERS+=("$CONTAINER_ID")
+            CONTAINER_MAPPINGS+=("{\"name\":\"$CONTAINER_NAME\",\"id\":\"$CONTAINER_ID\"}")
+                    
+            # Directory of docker container cgroups
+            CGROUP_DIR="/sys/fs/cgroup/system.slice/docker-${CONTAINER_ID}.scope"
+            
+            # Verify cgroup directory exists
+            if [[ -d "$CGROUP_DIR" ]]; then
+                continue
+            else
+                exit 1
+            fi
+        fi
+    done < <(docker ps --format '{{.Names}} {{.ID}}' --no-trunc | grep -v -E "$(IFS="|"; echo "${EXCLUDE_CONTAINERS[*]}")")
+
+    if [[ ${#CONTAINERS[@]} -eq 0 ]]; then
+        echo "No running containers found after filtering!"
+        exit 1
+    fi
+
+    # Prepare JSON array for stress_test
+    STRESS_TEST_JSON="["
+    for i in "${!CONTAINER_MAPPINGS[@]}"; do
+        STRESS_TEST_JSON+="${CONTAINER_MAPPINGS[$i]}"
+        if [[ $i -lt $((${#CONTAINER_MAPPINGS[@]} - 1)) ]]; then
+            STRESS_TEST_JSON+=","
+        fi
+    done
+    STRESS_TEST_JSON+="]"
+
+    # Update the "stress_test" section in test_input_template.json
+    jq --argjson stress_test "$STRESS_TEST_JSON" '.stress_test = $stress_test' test_input_template.json > $TEST_INPUT_TEMPLATE.tmp && mv $TEST_INPUT_TEMPLATE.tmp $TEST_INPUT_TEMPLATE
+
+    echo ""
+    echo "Total containers to stress test: ${#CONTAINERS[@]}"
+    echo "Updated 'stress_test' in: $TEST_INPUT_TEMPLATE"
+
+    # Display the updated JSON content
+    echo "Updated 'stress_test' section:"
+    jq '.stress_test' $TEST_INPUT_TEMPLATE
+}
+
+_generate_chaos_test_input() {
+    # Check if PICT and jq are installed
+    if ! command -v pict &> /dev/null; then
+        echo "Error: pict is required. Please install pict."
+        exit 1
+    fi
+    if ! command -v jq &> /dev/null; then
+        echo "Error: jq is required. Please install jq."
+        exit 1
+    fi
+
+    # List of container names to exclude
+    EXCLUDE_CONTAINERS=("kurtosis-" "validator-key-generation-cl-validator-keystore" "test-runner" "contracts-001")
+
+    # Get list of running container names, excluding specified ones, and join with commas
+    CONTAINERS=$(docker ps --format '{{.Names}}' | grep -v -E "$(IFS="|"; echo "${EXCLUDE_CONTAINERS[*]}")" | tr '\n' ',' | sed 's/,$//')
+
+    if [[ -z "$CONTAINERS" ]]; then
+        echo "No running containers found after filtering!"
+        exit 1
+    fi
+
+    # Create PICT model file
+    PICT_MODEL="chaos_test_model.pict"
+    {
+        echo "container: $CONTAINERS"
+        echo "percent: 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90"
+        echo "probability: 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9"
+        echo "rate: 50kbit, 100kbit, 150kbit, 200kbit, 250kbit, 300kbit, 350kbit, 400kbit, 450kbit, 500kbit, 550kbit, 600kbit, 650kbit, 700kbit, 750kbit, 800kbit, 850kbit, 900kbit"
+        echo "jitter: 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150"
+    } > "$PICT_MODEL"
+
+    # Generate test matrix with PICT and format as JSON, then update chaos_test section
+    CHAOS_JSON=$(pict "$PICT_MODEL" /r /o:1 | awk 'BEGIN {FS="\t"; print "["} NR>1 {if (NR>2) print ","; print "  {"; print "    \"container\": \"" $1 "\","; print "    \"percent\": " $2 ","; print "    \"probability\": " $3 ","; print "    \"rate\": \"" $4 "\","; print "    \"jitter\": " $5; print "  }"} END {print "]"}')
+
+    jq --argjson chaos_test "$CHAOS_JSON" '.chaos_test = $chaos_test' test_input_template.json > $TEST_INPUT_TEMPLATE.tmp && mv $TEST_INPUT_TEMPLATE.tmp $TEST_INPUT_TEMPLATE
+
+    echo "Updated 'chaos_test' in: $TEST_INPUT_TEMPLATE"
+    echo "Updated 'chaos_test' section:"
+    jq '.chaos_test' $TEST_INPUT_TEMPLATE
+}
+
+# Call the functions
+_generate_stress_test_input
+_generate_chaos_test_input
+
+# Remove PICT model file after test
+PICT_MODEL="chaos_test_model.pict"
+if [[ -f "$PICT_MODEL" ]]; then
+    rm "$PICT_MODEL"
+fi

--- a/scenarios/monitored-tests/pre-state/generate_test_input.bash
+++ b/scenarios/monitored-tests/pre-state/generate_test_input.bash
@@ -74,9 +74,10 @@ _generate_chaos_test_input() {
     EXCLUDE_CONTAINERS=("kurtosis-" "validator-key-generation-cl-validator-keystore" "test-runner" "contracts-001")
 
     # Get list of running container names, excluding specified ones, and join with commas
-    CONTAINERS=$(docker ps --format '{{.Names}}' | grep -v -E "$(IFS="|"; echo "${EXCLUDE_CONTAINERS[*]}")" | tr '\n' ',' | sed 's/,$//')
+    CONTAINER_LIST=$(docker ps --format '{{.Names}}' | grep -v -E "$(IFS="|"; echo "${EXCLUDE_CONTAINERS[*]}")" | tr '\n' ',' | sed 's/,$//')
 
-    if [[ -z "$CONTAINERS" ]]; then
+    # Check if CONTAINER_LIST is empty
+    if [[ -z "$CONTAINER_LIST" ]]; then
         echo "No running containers found after filtering!"
         exit 1
     fi
@@ -84,7 +85,7 @@ _generate_chaos_test_input() {
     # Create PICT model file
     PICT_MODEL="chaos_test_model.pict"
     {
-        echo "container: $CONTAINERS"
+        echo "container: $CONTAINER_LIST"
         echo "percent: 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90"
         echo "probability: 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9"
         echo "rate: 50kbit, 100kbit, 150kbit, 200kbit, 250kbit, 300kbit, 350kbit, 400kbit, 450kbit, 500kbit, 550kbit, 600kbit, 650kbit, 700kbit, 750kbit, 800kbit, 850kbit, 900kbit"

--- a/scenarios/stress-test/container-stress.bats
+++ b/scenarios/stress-test/container-stress.bats
@@ -217,7 +217,7 @@ EOF
     local test_type="memory_stress"
     
     for container_id in "${CONTAINER_IDS[@]}"; do
-        local stress_command="stress-ng --vm 2 --vm-bytes 128M -t $DURATION"
+        local stress_command="stress-ng --vm 4 --vm-bytes 1024M -t $DURATION"
         
         _run_stress_with_logging "$container_id" "$test_type" "$stress_command"
         local stress_status=$?


### PR DESCRIPTION
# Description
- Add docs to monitored-tests which orchestrate chaos + e2e tests
- Script to automate filling out `chaos_test` and `stress_test` sections
- Runs chaos tests against multiple containers in parallel

# Testing
Run the `generate_test_input.bash` script in the following directory:
```
cd ~/e2e/scenarios/monitored-tests/pre-state
./generate_test_input.bash
```

Then run the tests from the root directory:
```
cd ~/e2e
bats ./scenarios/monitored-tests/monitored-tests.bats
```

<img width="1077" height="531" alt="image" src="https://github.com/user-attachments/assets/5ea70161-6bc4-49d2-845d-74eeb50453c7" />
