### PR TITLE
fix: stake api urls and remove val test case

### DIFF
--- a/core/helpers/pos-setup.bash
+++ b/core/helpers/pos-setup.bash
@@ -24,8 +24,8 @@ pos_setup() {
     export L2_RPC_URL=${L2_RPC_URL:-$(kurtosis port print "${ENCLAVE_NAME}" "l2-el-1-bor-heimdall-validator" rpc)}
     export L2_CL_API_URL=${L2_CL_API_URL:-$(kurtosis port print "${ENCLAVE_NAME}" "l2-cl-1-heimdall-bor-validator" http)}
   elif [[ "${L2_CL_NODE_TYPE}" == "heimdall-v2" ]]; then
-    export L2_RPC_URL=${L2_RPC_URL:-$(kurtosis port print "${ENCLAVE_NAME}" "l2-el-1-bor-modified-for-heimdall-v2-heimdall-v2-validator" rpc)}
-    export L2_CL_API_URL=${L2_CL_API_URL:-$(kurtosis port print "${ENCLAVE_NAME}" "l2-cl-1-heimdall-v2-bor-modified-for-heimdall-v2-validator" http)}
+    export L2_RPC_URL=${L2_RPC_URL:-$(kurtosis port print "${ENCLAVE_NAME}" "l2-el-1-bor-heimdall-v2-validator" rpc)}
+    export L2_CL_API_URL=${L2_CL_API_URL:-$(kurtosis port print "${ENCLAVE_NAME}" "l2-cl-1-heimdall-v2-bor-validator" http)}
   fi
   echo "L2_RPC_URL=${L2_RPC_URL}"
   echo "L2_CL_API_URL=${L2_CL_API_URL}"


### PR DESCRIPTION
Tested locally.
Output:
```bash
krishangshah@Polygon-HCR66N076F e2e % curl "http://127.0.0.1:65193/stake/validators-set" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1623  100  1623    0     0   661k      0 --:--:-- --:--:-- --:--:--  792k
{
  "validator_set": {
    "validators": [
      {
        "val_id": "1",
        "start_epoch": "0",
        "end_epoch": "0",
        "nonce": "1",
        "voting_power": "1000000000",
        "pub_key": "BJPocX9GsUbr+5kVnrE6XQRMGRmYZWyLeQB7FgUbsf92LQmITkN4PYmN1H9iIK8EAgbKu9Rcmia7J4pSLD1Tih8=",
        "signer": "97538585a02A3f1B1297EB9979cE1b34ff953f1E",
        "last_updated": "",
        "jailed": false,
        "proposer_priority": "-1000000000"
      },
      {
        "val_id": "3",
        "start_epoch": "0",
        "end_epoch": "0",
        "nonce": "1",
        "voting_power": "1000000000",
        "pub_key": "BMwO60q+UgmZ7jEKoKmkhVJ+3VhMH9npmBFE/yxXTlv4e1VJkCr9BasrXFC9ix8sb2SNpxcj/fVyGv45xv5JGkU=",
        "signer": "A831F4E702F374aBf14d8005e21DC6d17d84DfCc",
        "last_updated": "",
        "jailed": false,
        "proposer_priority": "-1000000000"
      },
      {
        "val_id": "4",
        "start_epoch": "0",
        "end_epoch": "0",
        "nonce": "1",
        "voting_power": "1000000000",
        "pub_key": "BHnpyVMQDGJP/H8y9h+zePKBQb68ANUTdv2W1cGzFRfLExgvSJsORXhDDZ2Oct4b5RwMYk966obmUL+G09XaBjo=",
        "signer": "d3cc855bDb41498920792b77aBCB7431617fA9a4",
        "last_updated": "",
        "jailed": false,
        "proposer_priority": "-1000000000"
      },
      {
        "val_id": "2",
        "start_epoch": "0",
        "end_epoch": "0",
        "nonce": "1",
        "voting_power": "1000000000",
        "pub_key": "BA9VTa8ALDWSganFw8tmOcqxIln1cNbRDLFeP4KnnnWqSSTwH1MAaLSgET935pulQ0ygEQChgvvKJgninEqd6R8=",
        "signer": "eeE6f79486542f85290920073947bc9672C6ACE5",
        "last_updated": "",
        "jailed": false,
        "proposer_priority": "3000000000"
      }
    ],
    "proposer": {
      "val_id": "4",
      "start_epoch": "0",
      "end_epoch": "0",
      "nonce": "1",
      "voting_power": "1000000000",
      "pub_key": "BHnpyVMQDGJP/H8y9h+zePKBQb68ANUTdv2W1cGzFRfLExgvSJsORXhDDZ2Oct4b5RwMYk966obmUL+G09XaBjo=",
      "signer": "d3cc855bDb41498920792b77aBCB7431617fA9a4",
      "last_updated": "",
      "jailed": false,
      "proposer_priority": "-1000000000"
    },
    "total_voting_power": "4000000000"
  }
}
krishangshah@Polygon-HCR66N076F e2e % export L1_RPC_URL="$(kurtosis port print pos el-1-geth-lighthouse rpc)" && export L2_RPC_URL="$(kurtosis port print pos "l2-el-1-bor-heimdall-v2-validator" rpc)" && export L2_CL_API_URL="$(kurtosis port print pos "l2-cl-1-heimdall-v2-bor-validator" http)" && export L1_STAKE_MANAGER_PROXY_ADDRESS=$(kurtosis files inspect pos matic-contract-addresses contractAddresses.json | tail -n +2 | jq --raw-output '.root.StakeManagerProxy') && export L1_MATIC_TOKEN_ADDRESS=$(kurtosis files inspect pos matic-contract-addresses contractAddresses.json | tail -n +2 | jq --raw-output '.root.tokens.MaticToken') && export PRIVATE_KEY="0xacb8c67e52062f072e978d2dbfade9fe191f8ea50866cf99480c16926ec38f24" && export L2_CL_NODE_TYPE="heimdall-v2" && export ENCLAVE_NAME="pos" && bats --filter "remove validator" tests/pos/validator.bats
validator.bats
 ✓ remove validator

1 test, 0 failures

krishangshah@Polygon-HCR66N076F e2e % curl "http://127.0.0.1:65193/stake/validators-set" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1309  100  1309    0     0   849k      0 --:--:-- --:--:-- --:--:-- 1278k
{
  "validator_set": {
    "validators": [
      {
        "val_id": "3",
        "start_epoch": "0",
        "end_epoch": "0",
        "nonce": "1",
        "voting_power": "1000000000",
        "pub_key": "BMwO60q+UgmZ7jEKoKmkhVJ+3VhMH9npmBFE/yxXTlv4e1VJkCr9BasrXFC9ix8sb2SNpxcj/fVyGv45xv5JGkU=",
        "signer": "A831F4E702F374aBf14d8005e21DC6d17d84DfCc",
        "last_updated": "",
        "jailed": false,
        "proposer_priority": "-333333333"
      },
      {
        "val_id": "4",
        "start_epoch": "0",
        "end_epoch": "0",
        "nonce": "1",
        "voting_power": "1000000000",
        "pub_key": "BHnpyVMQDGJP/H8y9h+zePKBQb68ANUTdv2W1cGzFRfLExgvSJsORXhDDZ2Oct4b5RwMYk966obmUL+G09XaBjo=",
        "signer": "d3cc855bDb41498920792b77aBCB7431617fA9a4",
        "last_updated": "",
        "jailed": false,
        "proposer_priority": "-333333333"
      },
      {
        "val_id": "2",
        "start_epoch": "0",
        "end_epoch": "0",
        "nonce": "1",
        "voting_power": "1000000000",
        "pub_key": "BA9VTa8ALDWSganFw8tmOcqxIln1cNbRDLFeP4KnnnWqSSTwH1MAaLSgET935pulQ0ygEQChgvvKJgninEqd6R8=",
        "signer": "eeE6f79486542f85290920073947bc9672C6ACE5",
        "last_updated": "",
        "jailed": false,
        "proposer_priority": "666666667"
      }
    ],
    "proposer": {
      "val_id": "2",
      "start_epoch": "0",
      "end_epoch": "0",
      "nonce": "1",
      "voting_power": "1000000000",
      "pub_key": "BA9VTa8ALDWSganFw8tmOcqxIln1cNbRDLFeP4KnnnWqSSTwH1MAaLSgET935pulQ0ygEQChgvvKJgninEqd6R8=",
      "signer": "eeE6f79486542f85290920073947bc9672C6ACE5",
      "last_updated": "",
      "jailed": false,
      "proposer_priority": "666666667"
    },
    "total_voting_power": "3000000000"
  }
}
krishangshah@Polygon-HCR66N076F e2e % 
```
We can see the validator with `"val_id": "1"` getting removed.