### PR TITLE
feat: disk read/write stressor

### DIFF
--- a/scenarios/stress-test/container-stress.bats
+++ b/scenarios/stress-test/container-stress.bats
@@ -238,3 +238,17 @@ EOF
         [[ "$stress_status" -eq 0 ]]
     done
 }
+
+@test "Disk Read/Write stress test" {
+    local test_type="disk_read_write_stress"
+
+    for container_id in "${CONTAINER_IDS[@]}"; do
+        local stress_command="stress-ng --hdd 8 --io 8 --vm 8 -t $DURATION"
+
+        _run_stress_with_logging "$container_id" "$test_type" "$stress_command"
+
+        local stress_status=$?
+
+        [[ "$stress_status" -eq 0 ]]
+    done
+}


### PR DESCRIPTION
# Description

This PR adds the disk read/write stressor into container-stress tests

## Relevant discussions 

[#10](https://github.com/orgs/0xPolygon/projects/13/views/1?sliceBy%5Bvalue%5D=jhkimqd&pane=issue&itemId=99166961&issue=0xPolygon%7Cchaos-test-orchestrator%7C10)

## Testing

```
# change directory to test dir
cd ~/e2e/scenarios/stress-test/assets
# run setup script to generate container mappings
bash generate-container-mappings.sh

# change directory to bats test
cd ~/e2e/scenarios/stress-test
# run bats test targetting disk read/write test
bats --filter "Disk Read/Write stress test" container-stress.bats
```