### PR TITLE
feat: quality of life cleanup for rpc tests

### DIFF
--- a/.github/workflows/standard-battery-tests-rpc.yml
+++ b/.github/workflows/standard-battery-tests-rpc.yml
@@ -22,6 +22,14 @@ on:
         options:
           - cardona
           - bali
+      user-input-gas-token-address:
+        description: "l2 gas token address contract on l1 - overrides default value"
+        required: false
+        type: string
+      user-input-bridge-service-url:
+        description: "l2 bridge service endpoint - overrides default value"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -177,9 +185,20 @@ jobs:
 
           # Set sensitive values from GitHub secrets
           export L1_RPC_URL="${{ env.L1_RPC_ENDPOINT }}"
-          export L1_PRIVATE_KEY="${{ env.L1_FUNDED_PRIVATE_KEY }}"
           export L2_RPC_URL="${{ env.L2_RPC_ENDPOINT }}"
+          export L1_PRIVATE_KEY="${{ env.L1_FUNDED_PRIVATE_KEY }}"
           export L2_PRIVATE_KEY="${{ env.L2_FUNDED_PRIVATE_KEY }}"
+
+          # Override below values if provided by user input
+          if [[ -n "${{ inputs.user-input-gas-token-address }}" ]]; then
+            echo "Using user-provided gas token address"
+            export GAS_TOKEN_ADDRESS="${{ inputs.user-input-gas-token-address }}"
+          fi
+
+          if [[ -n "${{ inputs.user-input-bridge-service-url }}" ]]; then
+            echo "Using user-provided bridge service URL"
+            export BRIDGE_SERVICE_URL="${{ inputs.user-input-bridge-service-url }}"
+          fi
 
           bats --filter-tags standard ${{ matrix.testfile }}
           popd

--- a/tests/execution/conflicting-contract-calls.bats
+++ b/tests/execution/conflicting-contract-calls.bats
@@ -59,7 +59,7 @@ is_cdk_erigon() {
     
     echo "ephemeral_address: $ephemeral_address" >&3
     # Fund the ephemeral account using imported function
-    _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "1000000000000000000"
+    _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "10000000000000000"
     
     index=0;
     nonce=$(cast nonce --rpc-url "$l2_rpc_url" "$ephemeral_address")

--- a/tests/execution/conflicting-transactions-to-pool.bats
+++ b/tests/execution/conflicting-transactions-to-pool.bats
@@ -23,7 +23,7 @@ setup() {
     
     echo "ephemeral_address: $ephemeral_address" >&3
     # Fund the ephemeral account using imported function
-    _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "1000000000000000000"
+    _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "10000000000000000"
     
     nonce=$(cast nonce --rpc-url "$l2_rpc_url" "$ephemeral_address")
     gas_price=$(cast gas-price --rpc-url "$l2_rpc_url")
@@ -37,7 +37,7 @@ setup() {
             --async \
             --legacy \
             --private-key "$ephemeral_private_key" \
-            --value 0.5ether \
+            --value 0.000000001ether \
             0xC0FFEE0000000000000000000000000000000000;
     if [[ "$status" -ne 0 ]]; then
         echo "Test expected success but failed: $output" >&3
@@ -55,7 +55,7 @@ setup() {
             --gas-limit 100000 \
             --gas-price "$gas_price" \
             --legacy \
-            --value 0.5ether\
+            --value 0.000000001ether\
             --private-key "$ephemeral_private_key" \
             --create \
             0x60005B60010180405063000000025600

--- a/tests/execution/polycli-cases.bats
+++ b/tests/execution/polycli-cases.bats
@@ -16,7 +16,7 @@ setup_file() {
 
     echo "ephemeral_address: $ephemeral_address" >&3
     # Fund the ephemeral account using imported function
-    _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "100000000000000000000"
+    _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "10000000000000000"
 
     # Export variables for use in tests
     export ephemeral_private_key

--- a/tests/execution/smooth-crypto-lib.bats
+++ b/tests/execution/smooth-crypto-lib.bats
@@ -89,7 +89,7 @@ setup() {
         ephemeral_address=$(echo "$ephemeral_data" | cut -d' ' -f2)
         
         # Fund ephemeral account
-        _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "1000000000000000000" &
+        _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "10000000000000000" &
         
         # Small delay to prevent overwhelming the network
         if (( i % 20 == 0 )); then
@@ -135,7 +135,7 @@ setup() {
         ephemeral_private_key=$(echo "$ephemeral_data" | cut -d' ' -f1)
         ephemeral_address=$(echo "$ephemeral_data" | cut -d' ' -f2)
 
-        _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "1000000000000000000" &
+        _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "10000000000000000" &
         
         if (( i % 20 == 0 )); then
             wait
@@ -178,7 +178,7 @@ setup() {
 #         local ephemeral_private_key=$(echo "$ephemeral_data" | cut -d' ' -f1)
 #         local ephemeral_address=$(echo "$ephemeral_data" | cut -d' ' -f2)
         
-#         _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "1000000000000000000" &
+#         _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "10000000000000000" &
         
 #         if (( i % 20 == 0 )); then
 #             wait
@@ -217,7 +217,7 @@ setup() {
 #         local ephemeral_private_key=$(echo "$ephemeral_data" | cut -d' ' -f1)
 #         local ephemeral_address=$(echo "$ephemeral_data" | cut -d' ' -f2)
         
-#         _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "1000000000000000000" &
+#         _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "10000000000000000" &
         
 #         if (( i % 20 == 0 )); then
 #             wait
@@ -272,7 +272,7 @@ setup() {
         ephemeral_private_key=$(echo "$ephemeral_data" | cut -d' ' -f1)
         ephemeral_address=$(echo "$ephemeral_data" | cut -d' ' -f2)
         
-        _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "1000000000000000000" &
+        _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "10000000000000000" &
         
         if (( i % 20 == 0 )); then
             wait
@@ -331,7 +331,7 @@ setup() {
 #         local ephemeral_private_key=$(echo "$ephemeral_data" | cut -d' ' -f1)
 #         local ephemeral_address=$(echo "$ephemeral_data" | cut -d' ' -f2)
         
-#         _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "1000000000000000000" &
+#         _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "10000000000000000" &
         
 #         if (( i % 20 == 0 )); then
 #             wait
@@ -387,7 +387,7 @@ setup() {
 #         local ephemeral_private_key=$(echo "$ephemeral_data" | cut -d' ' -f1)
 #         local ephemeral_address=$(echo "$ephemeral_data" | cut -d' ' -f2)
         
-#         _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "1000000000000000000" &
+#         _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "10000000000000000" &
         
 #         if (( i % 20 == 0 )); then
 #             wait
@@ -443,7 +443,7 @@ setup() {
         ephemeral_private_key=$(echo "$ephemeral_data" | cut -d' ' -f1)
         ephemeral_address=$(echo "$ephemeral_data" | cut -d' ' -f2)
         
-        _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "1000000000000000000" &
+        _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "10000000000000000" &
         
         if (( i % 20 == 0 )); then
             wait
@@ -501,7 +501,7 @@ setup() {
         ephemeral_private_key=$(echo "$ephemeral_data" | cut -d' ' -f1)
         ephemeral_address=$(echo "$ephemeral_data" | cut -d' ' -f2)
         
-        _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "1000000000000000000" &
+        _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "10000000000000000" &
         
         if (( i % 20 == 0 )); then
             wait
@@ -552,7 +552,7 @@ setup() {
         ephemeral_private_key=$(echo "$ephemeral_data" | cut -d' ' -f1)
         ephemeral_address=$(echo "$ephemeral_data" | cut -d' ' -f2)
         
-        _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "1000000000000000000" &
+        _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "10000000000000000" &
         
         if (( i % 30 == 0 )); then
             wait
@@ -606,7 +606,7 @@ setup() {
 #         local ephemeral_private_key=$(echo "$ephemeral_data" | cut -d' ' -f1)
 #         local ephemeral_address=$(echo "$ephemeral_data" | cut -d' ' -f2)
         
-#         _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "1000000000000000000" &
+#         _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "10000000000000000" &
         
 #         if (( i % 20 == 0 )); then
 #             wait
@@ -633,7 +633,7 @@ setup() {
 #         local ephemeral_private_key=$(echo "$ephemeral_data" | cut -d' ' -f1)
 #         local ephemeral_address=$(echo "$ephemeral_data" | cut -d' ' -f2)
         
-#         _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "1000000000000000000" &
+#         _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "10000000000000000" &
         
 #         if (( i % 20 == 0 )); then
 #             wait
@@ -674,7 +674,7 @@ setup() {
         ephemeral_private_key=$(echo "$ephemeral_data" | cut -d' ' -f1)
         ephemeral_address=$(echo "$ephemeral_data" | cut -d' ' -f2)
         
-        _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "1000000000000000000" &
+        _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "10000000000000000" &
         
         if (( i % 20 == 0 )); then
             wait
@@ -724,7 +724,7 @@ setup() {
         ephemeral_private_key=$(echo "$ephemeral_data" | cut -d' ' -f1)
         ephemeral_address=$(echo "$ephemeral_data" | cut -d' ' -f2)
         
-        _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "1000000000000000000" &
+        _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "10000000000000000" &
         
         if (( i % 20 == 0 )); then
             wait

--- a/tests/execution/special-addresses.bats
+++ b/tests/execution/special-addresses.bats
@@ -23,7 +23,7 @@ setup() {
     
     echo "ephemeral_address: $ephemeral_address" >&3
     # Fund the ephemeral account using imported function
-    _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "1000000000000000000"
+    _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "10000000000000000"
     
     nonce=$(cast nonce --rpc-url "$l2_rpc_url" "$ephemeral_address")
     cast send --async --nonce "$nonce" --legacy --from "$ephemeral_address" --private-key "$ephemeral_private_key" --rpc-url "$l2_rpc_url" --gas-limit 100000 --value 2 --json "0x0000000000000000000000000000000000000000" >> well-known-addresses.out

--- a/tests/lxly/assets/bridge-tests-helper.bash
+++ b/tests/lxly/assets/bridge-tests-helper.bash
@@ -715,7 +715,7 @@ _setup_single_test_account() {
     # Fund ephemeral account with native tokens on L2 (if needed for claims later)
     echo "DEBUG: Funding L2 account for test $test_index" >&2
     # shellcheck disable=SC2154
-    if ! _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "1000000000000000000"; then
+    if ! _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "10000000000000000"; then
         echo "DEBUG: Failed to fund L2 account for test $test_index" >&2
         return 1
     fi

--- a/tests/polycli-loadtests/polycli-loadtests.bats
+++ b/tests/polycli-loadtests/polycli-loadtests.bats
@@ -34,7 +34,7 @@ setup() {
 
     echo "ephemeral_address: $ephemeral_address" >&3
     # Fund the ephemeral account using imported function
-    _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "1000000000000000000"
+    _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "10000000000000000"
 
     sleep 1
 
@@ -64,7 +64,7 @@ setup() {
 
     echo "ephemeral_address: $ephemeral_address" >&3
     # Fund the ephemeral account using imported function
-    _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "1000000000000000000"
+    _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "10000000000000000"
 
     sleep 1
 
@@ -95,7 +95,7 @@ setup() {
 
     echo "ephemeral_address: $ephemeral_address" >&3
     # Fund the ephemeral account using imported function
-    _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "1000000000000000000"
+    _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "10000000000000000"
 
     sleep 1
 
@@ -128,7 +128,7 @@ setup() {
 
     echo "ephemeral_address: $ephemeral_address" >&3
     # Fund the ephemeral account using imported function
-    _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "1000000000000000000"
+    _fund_ephemeral_account "$ephemeral_address" "$l2_rpc_url" "$l2_private_key" "10000000000000000"
 
     sleep 1
 


### PR DESCRIPTION
# Description

- Reduce amount of L2 native gas token needed to run the tests
    - Reduce `_fund_ephemeral_account` 1eth -> 0.01eth
    - Also reduce send `--value` in standard battery tests 
- Allow user input for `user-input-gas-token-address` and `user-input-bridge-service-url` to target custom networks
    - L2 RPC will still need to be changed in gh secrets