### PR TITLE
feat: add test to reclaim funds after test

### DIFF
--- a/.github/workflows/standard-battery-tests-nightly-kurtosis.yml
+++ b/.github/workflows/standard-battery-tests-nightly-kurtosis.yml
@@ -2,8 +2,8 @@ name: Standard Battery Tests - Kurtosis (Nightly)
 
 on:
   schedule:
-    # Run at 1:00 AM UTC every day
-    - cron: '0 1 * * *'
+    # Run at 00:00 AM UTC every day
+    - cron: '0 0 * * *'
   workflow_dispatch:
     inputs:
       agglayer-e2e-ref:

--- a/.github/workflows/standard-battery-tests-nightly-rpc.yml
+++ b/.github/workflows/standard-battery-tests-nightly-rpc.yml
@@ -4,8 +4,8 @@ name: Standard Battery Tests - RPC (Nightly)
 
 on:
   schedule:
-    # Run at 3:00 AM UTC every day
-    - cron: '0 3 * * *'
+    # Run at 5:00 AM UTC every day
+    - cron: '0 5 * * *'
   workflow_dispatch:
     inputs:
       agglayer-e2e-ref:

--- a/core/helpers/logger.bash
+++ b/core/helpers/logger.bash
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+function _log_file_descriptor() {
+    local file_descriptor=$1
+    local log_output=$2
+
+    # Create the log message
+    log_message="[$(date '+%Y-%m-%d %H:%M:%S')]: $log_output"
+
+    # Output based on file descriptor
+    # File descriptor 1 (stdout)
+    # File descriptor 2 (stderr)
+    # File descriptor 3 (and higher)
+    if [[ "$file_descriptor" == "1" ]]; then
+        echo "$log_message" >&1
+    elif [[ "$file_descriptor" == "2" ]]; then
+        echo "$log_message" >&2
+    else
+        echo "$log_message" >&3
+    fi
+}

--- a/tests/execution/conflicting-contract-calls.bats
+++ b/tests/execution/conflicting-contract-calls.bats
@@ -19,8 +19,8 @@ wait_block_increment() {
     local timeout_seconds="$2"
 
     start_block=$(cast block-number --rpc-url "$l2_rpc_url")
-    echo "DEBUG: starting block: $start_block" >&3
-    echo "DEBUG: waiting until: $((start_block + wait_blocks))" >&3
+    echo "[DEBUG]: starting block: $start_block" >&3
+    echo "[DEBUG]: waiting until: $((start_block + wait_blocks))" >&3
     block_diff=0
     start_time=$(date +%s)
     
@@ -34,7 +34,7 @@ wait_block_increment() {
         fi
         
         current_block=$(cast block-number --rpc-url "$l2_rpc_url")
-        echo "DEBUG: current block: $current_block" >&3
+        echo "[DEBUG]: current block: $current_block" >&3
         block_diff=$((current_block - start_block))
         sleep 1
     done
@@ -70,7 +70,7 @@ is_cdk_erigon() {
         if [[ $index -gt "$iteration_count" ]]; then
             break;
         fi
-        echo "DEBUG: cast send --nonce \"$nonce\" --rpc-url \"$l2_rpc_url\" --gas-limit 21000 --gas-price \"$gas_price\" --async --legacy --private-key \"$ephemeral_private_key\" --value $index 0x0000000000000000000000000000000000000000" >&2
+        echo "[DEBUG]: cast send --nonce \"$nonce\" --rpc-url \"$l2_rpc_url\" --gas-limit 21000 --gas-price \"$gas_price\" --async --legacy --private-key \"$ephemeral_private_key\" --value $index 0x0000000000000000000000000000000000000000" >&2
         # this should work
         run cast send \
             --nonce "$nonce" \
@@ -88,7 +88,7 @@ is_cdk_erigon() {
         fi
         echo "Test $index transaction hash: $output" >&2
         index=$((index+1));
-        echo "DEBUG: cast send --nonce \"$nonce\" --rpc-url \"$l2_rpc_url\" --gas-limit 21000 --gas-price \"$gas_price\" --async --legacy --private-key \"$ephemeral_private_key\" --value $index 0x0000000000000000000000000000000000000000" >&2
+        echo "[DEBUG]: cast send --nonce \"$nonce\" --rpc-url \"$l2_rpc_url\" --gas-limit 21000 --gas-price \"$gas_price\" --async --legacy --private-key \"$ephemeral_private_key\" --value $index 0x0000000000000000000000000000000000000000" >&2
         # this should fail
         run cast send \
             --nonce "$nonce" \
@@ -109,7 +109,7 @@ is_cdk_erigon() {
             if [[ "$txn_status" -eq 0 ]]; then
                 # for cdk-erigon, even invalid transactions can exist in the pool for a short time before being rejected
                 # wait for 3 blocks and then recheck if the transaction hash exists
-                echo "DEBUG: cdk-erigon detected" >&2
+                echo "[DEBUG]: cdk-erigon detected" >&2
                 # usage: wait_block_increment <number_of_blocks_to_wait> <timeout_in_seconds>
                 wait_block_increment 12 144
                 # command succeeded, now check if transaction failed

--- a/tests/lxly/assets/bridge-tests-helper.bash
+++ b/tests/lxly/assets/bridge-tests-helper.bash
@@ -147,7 +147,7 @@ _fund_ephemeral_account() {
     # Check if target address already has sufficient balance (more than 1 ETH)
     local target_balance
     target_balance=$(cast balance --rpc-url "$rpc_url" "$target_address")
-    local threshold="500000000000000000"  # 0.5 ETH in wei
+    local threshold="100000000000000000"  # 0.1 ETH in wei
     
     echo "DEBUG: Target address balance: $target_balance" >&2
     echo "DEBUG: Funding threshold: $threshold" >&2
@@ -816,7 +816,7 @@ _setup_single_test_account() {
     
     # Fund ephemeral account with native tokens on source network (where bridging happens from)
     echo "DEBUG: Funding source network account for test $test_index ($bridge_direction)" >&2
-    if ! _fund_ephemeral_account "$ephemeral_address" "$source_rpc_url" "$source_private_key" "1000000000000000000"; then
+    if ! _fund_ephemeral_account "$ephemeral_address" "$source_rpc_url" "$source_private_key" "100000000000000000"; then
         echo "DEBUG: Failed to fund source network account for test $test_index" >&2
         return 1
     fi
@@ -829,15 +829,15 @@ _setup_single_test_account() {
     fi
     
     # Setup tokens for ephemeral account on source network
-    local amount_for_setup="100000000000000000000" # 100 tokens
+    local amount_for_setup="100000000000000000000"
     if [[ "$test_amount" == "Max" ]]; then
         # Special handling for POL with max amount and max metadata
         if [[ "$test_token" == "POL" && "$test_meta_data" == "Max" ]]; then
             # Use even smaller amount for this problematic combination
-            amount_for_setup="100000000000000000000000"  # 100,000 tokens
+            amount_for_setup="100000000000000000000000"
             echo "DEBUG: Using reduced amount $amount_for_setup for POL Max+Max combination" >&2
         elif [[ "$test_token" == "LocalERC20" || "$test_token" == "POL" ]]; then
-            amount_for_setup="1000000000000000000000000000"  # 1,000,000,000 tokens
+            amount_for_setup="1000000000000000000000000000"
         else
             amount_for_setup="$(cast max-uint)"
         fi

--- a/tests/lxly/assets/bridge-tests-helper.bash
+++ b/tests/lxly/assets/bridge-tests-helper.bash
@@ -5,7 +5,7 @@ deploy_buggy_erc20() {
     local private_key=$2
     local eth_address=$3
     local bridge_address=$4
-    echo "Deploying Buggy ERC20 - RPC: $rpc_url, Address: $eth_address, Bridge: $bridge_address" >&3
+    echo "[DEBUG]: Deploying Buggy ERC20 - RPC: $rpc_url, Address: $eth_address, Bridge: $bridge_address" >&3
 
     salt="0x0000000000000000000000000000000000000000000000000000000000000000"
     deterministic_deployer_addr="0x4e59b44847b379578588920ca78fbf26c0b4956c"
@@ -14,22 +14,22 @@ deploy_buggy_erc20() {
     # This contract is a weird ERC20 that has a infinite money glitch and allows for some bizarre testing
     constructor_args=$(cast abi-encode 'f(string,string,uint8)' 'Buggy ERC20' 'BUG' "18" | sed 's/0x//')
     test_erc20_buggy_addr=$(cast create2 --salt $salt --init-code $erc20_buggy_bytecode"$constructor_args")
-    echo "Calculated Buggy ERC20 address: $test_erc20_buggy_addr" >&3
+    echo "[DEBUG]: Calculated Buggy ERC20 address: $test_erc20_buggy_addr" >&3
 
     if [[ $(cast code --rpc-url "$rpc_url" "$test_erc20_buggy_addr") != "0x" ]]; then
-        echo "The network on $rpc_url already has the Buggy ERC20 deployed. Skipping deployment..." >&3
+        echo "[DEBUG]: The network on $rpc_url already has the Buggy ERC20 deployed. Skipping deployment..." >&3
     else
-        echo "Deploying Buggy ERC20 to $rpc_url..." >&3
+        echo "[DEBUG]: Deploying Buggy ERC20 to $rpc_url..." >&3
         cast send --rpc-url "$rpc_url" --private-key "$private_key" "$deterministic_deployer_addr" "$salt$erc20_buggy_bytecode$constructor_args"
-        echo "Deployment transaction sent." >&3
+        echo "[DEBUG]: Deployment transaction sent." >&3
 
-        echo "Minting max uint tokens to $eth_address..." >&3
+        echo "[DEBUG]: Minting max uint tokens to $eth_address..." >&3
         cast send --rpc-url "$rpc_url" --private-key "$private_key" "$test_erc20_buggy_addr" 'mint(address,uint256)' "$eth_address" "$(cast max-uint)"
-        echo "Minting completed." >&3
+        echo "[DEBUG]: Minting completed." >&3
 
-        echo "Approving max uint tokens for bridge $bridge_address..." >&3
+        echo "[DEBUG]: Approving max uint tokens for bridge $bridge_address..." >&3
         cast send --rpc-url "$rpc_url" --private-key "$private_key" "$test_erc20_buggy_addr" 'approve(address,uint256)' "$bridge_address" "$(cast max-uint)"
-        echo "Approval completed." >&3
+        echo "[DEBUG]: Approval completed." >&3
     fi
 }
 
@@ -39,7 +39,7 @@ deploy_test_erc20() {
     local private_key=$2
     local eth_address=$3
     local bridge_address=$4
-    echo "Deploying Test ERC20 - RPC: $rpc_url, Address: $eth_address, Bridge: $bridge_address" >&3
+    echo "[DEBUG]: Deploying Test ERC20 - RPC: $rpc_url, Address: $eth_address, Bridge: $bridge_address" >&3
 
     salt="0x0000000000000000000000000000000000000000000000000000000000000000"
     deterministic_deployer_addr="0x4e59b44847b379578588920ca78fbf26c0b4956c"
@@ -47,18 +47,18 @@ deploy_test_erc20() {
     
     constructor_args=$(cast abi-encode 'f(string,string,address,uint256)' 'Bridge Test' 'BT' "$eth_address" 100000000000000000000 | sed 's/0x//')
     test_erc20_addr=$(cast create2 --salt $salt --init-code $erc_20_bytecode"$constructor_args")
-    echo "Calculated Test ERC20 address: $test_erc20_addr" >&3
+    echo "[DEBUG]: Calculated Test ERC20 address: $test_erc20_addr" >&3
 
     if [[ $(cast code --rpc-url "$rpc_url" "$test_erc20_addr") != "0x" ]]; then
-        echo "The network on $rpc_url already has the Test ERC20 deployed. Skipping deployment..." >&3
+        echo "[DEBUG]: The network on $rpc_url already has the Test ERC20 deployed. Skipping deployment..." >&3
     else
-        echo "Deploying Test ERC20 to $rpc_url..." >&3
+        echo "[DEBUG]: Deploying Test ERC20 to $rpc_url..." >&3
         cast send --rpc-url "$rpc_url" --private-key "$private_key" "$deterministic_deployer_addr" "$salt$erc_20_bytecode$constructor_args"
-        echo "Deployment transaction sent." >&3
+        echo "[DEBUG]: Deployment transaction sent." >&3
 
-        echo "Approving max uint tokens for bridge $bridge_address..." >&3
+        echo "[DEBUG]: Approving max uint tokens for bridge $bridge_address..." >&3
         cast send --rpc-url "$rpc_url" --private-key "$private_key" "$test_erc20_addr" 'approve(address,uint256)' "$bridge_address" "$(cast max-uint)"
-        echo "Approval completed." >&3
+        echo "[DEBUG]: Approval completed." >&3
     fi
 }
 
@@ -67,7 +67,7 @@ deploy_lxly_proxy() {
     local rpc_url=$1
     local private_key=$2
     local bridge_address=$3
-    echo "Deploying LxLy Proxy - RPC: $rpc_url, Bridge: $bridge_address" >&3
+    echo "[DEBUG]: Deploying LxLy Proxy - RPC: $rpc_url, Bridge: $bridge_address" >&3
 
     salt="0x0000000000000000000000000000000000000000000000000000000000000000"
     deterministic_deployer_addr="0x4e59b44847b379578588920ca78fbf26c0b4956c"
@@ -75,14 +75,14 @@ deploy_lxly_proxy() {
     
     constructor_args=$(cast abi-encode 'f(address)' "$bridge_address" | sed 's/0x//')
     test_lxly_proxy_addr=$(cast create2 --salt $salt --init-code $lxly_proxy_bytecode"$constructor_args")
-    echo "Calculated LxLy Proxy address: $test_lxly_proxy_addr" >&3
+    echo "[DEBUG]: Calculated LxLy Proxy address: $test_lxly_proxy_addr" >&3
 
     if [[ $(cast code --rpc-url "$rpc_url" "$test_lxly_proxy_addr") != "0x" ]]; then
-        echo "The network on $rpc_url already has the LxLy Proxy deployed. Skipping deployment..." >&3
+        echo "[DEBUG]: The network on $rpc_url already has the LxLy Proxy deployed. Skipping deployment..." >&3
     else
-        echo "Deploying LxLy Proxy to $rpc_url..." >&3
+        echo "[DEBUG]: Deploying LxLy Proxy to $rpc_url..." >&3
         cast send --rpc-url "$rpc_url" --private-key "$private_key" $deterministic_deployer_addr $salt$lxly_proxy_bytecode"$constructor_args"
-        echo "Deployment transaction sent." >&3
+        echo "[DEBUG]: Deployment transaction sent." >&3
     fi
 }
 
@@ -90,21 +90,21 @@ deploy_lxly_proxy() {
 deploy_tester_contract() {
     local rpc_url=$1
     local private_key=$2
-    echo "Deploying Tester Contract - RPC: $rpc_url" >&3
+    echo "[DEBUG]: Deploying Tester Contract - RPC: $rpc_url" >&3
 
     salt="0x0000000000000000000000000000000000000000000000000000000000000000"
     deterministic_deployer_addr="0x4e59b44847b379578588920ca78fbf26c0b4956c"
     address_tester_bytecode=6300000dac63000000156000396300000dac6000F3366060811015610032577f6e6f7420656e6f7567682063616c6c6461746100000000000000000000000000805f5260205ffd5b5f356020356040356060840380606060c0375f845f528360205282604052600185612000116110008711161561006f576110008603915061100195505b85613000116120008711161561008c576120008603915061200195505b85600181146101a057600281146101b057600381146101c057600481146101cf57601181146101de57601281146101fe576013811461021e576014811461023e576021811461025e576022811461027e576023811461029e57602481146102be57603181146102de57603281146102fd576033811461031c576034811461033b576041811461035a5760428114610379576043811461039857604481146103b75761010181146103d657610201811461041a57610301811461045e5761040181146104a25761050181146104e657610601811461052a57610701811461056d5761080181146105b15761090181146105f557611001811461063857612001811461067f575f9150644641494c215f526106c3565b5f808560c0888a5af191506106c3565b5f808560c0888a5af291506106c3565b5f808560c0895af491506106c3565b5f808560c0895afa91506106c3565b6001606052856080528460a0525f8085606001606088305af191506106c3565b6002606052856080528460a0525f8085606001606088305af191506106c3565b6003606052856080528460a0525f8085606001606088305af191506106c3565b6004606052856080528460a0525f8085606001606088305af191506106c3565b6001606052856080528460a0525f8085606001606088305af291506106c3565b6002606052856080528460a0525f8085606001606088305af291506106c3565b6003606052856080528460a0525f8085606001606088305af291506106c3565b6004606052856080528460a0525f8085606001606088305af291506106c3565b6001606052856080528460a0525f80856060016060305af491506106c3565b6002606052856080528460a0525f80856060016060305af491506106c3565b6003606052856080528460a0525f80856060016060305af491506106c3565b6004606052856080528460a0525f80856060016060305af491506106c3565b6001606052856080528460a0525f80856060016060305afa91506106c3565b6002606052856080528460a0525f80856060016060305afa91506106c3565b6003606052856080528460a0525f80856060016060305afa91506106c3565b6004606052856080528460a0525f80856060016060305afa91506106c3565b7f600e600c600039600e6000f3600160015b8101906300000004560000000000005f5260205f80f05f805f805f8561c350f1505f808660c0898b5af19250506106c3565b7f6009600c60003960096000f3fe60005260206000f300000000000000000000005f5260205f80f05f805f805f8561c350f1505f808660c0898b5af19250506106c3565b7f6001600c60003960016000f350000000000000000000000000000000000000005f5260205f80f05f805f805f8561c350f1505f808660c0898b5af19250506106c3565b7f6007600c60003960076000f35b63ffffffff56000000000000000000000000005f5260205f80f05f805f805f8561c350f1505f808660c0898b5af19250506106c3565b7f6008600c60003960086000f35b5f6300000000560000000000000000000000005f5260205f80f05f805f805f8561c350f1505f808660c0898b5af19250506106c3565b7f6003600c60003960036000f35f5f5500000000000000000000000000000000005f5260205f80f05f805f808461c350fa505f808660c0898b5af19250506106c3565b7f6008600c60003960086000f360015f5560025f550000000000000000000000005f5260205f80f05f805f805f856156c2f1505f808660c0898b5af19250506106c3565b7f6002600c60003960026000f332ff0000000000000000000000000000000000005f5260205f80f05f805f805f856156c2f1505f808660c0898b5af19250506106c3565b7f6002600c60003960026000f332ff0000000000000000000000000000000000005f5260205f80f05f805f80846156c2fa505f808660c0898b5af19250506106c3565b82606052856080528460a0527f333b5f5f333c595ff300000000000000000000000000000000000000000000005f5260205f80f05f8086606001606089855af150506106c3565b82606052856080528460a0527f333b5f5f333c595ff300000000000000000000000000000000000000000000005f524460205f80f55f8086606001606089855af150505b50806106ce5760205ffd5b50505050505050
     
     tester_contract_address=$(cast create2 --salt $salt --init-code $address_tester_bytecode)
-    echo "Calculated Tester Contract address: $tester_contract_address" >&3
+    echo "[DEBUG]: Calculated Tester Contract address: $tester_contract_address" >&3
 
     if [[ $(cast code --rpc-url "$rpc_url" "$tester_contract_address") != "0x" ]]; then
-        echo "The network on $rpc_url already has the Tester Contract deployed. Skipping deployment..." >&3
+        echo "[DEBUG]: The network on $rpc_url already has the Tester Contract deployed. Skipping deployment..." >&3
     else
-        echo "Deploying Tester Contract to $rpc_url..." >&3
+        echo "[DEBUG]: Deploying Tester Contract to $rpc_url..." >&3
         cast send --rpc-url "$rpc_url" --private-key "$private_key" $deterministic_deployer_addr $salt$address_tester_bytecode
-        echo "Deployment transaction sent." >&3
+        echo "[DEBUG]: Deployment transaction sent." >&3
     fi
 }
 
@@ -136,11 +136,11 @@ _fund_ephemeral_account() {
     local funding_private_key="$3"
     local amount="$4"
     
-    echo "DEBUG: Funding $target_address with $amount on $rpc_url" >&2
+    echo "[DEBUG]: Funding $target_address with $amount on $rpc_url" >&2
     
     # First check if the RPC is reachable
     if ! cast chain-id --rpc-timeout 5 --rpc-url "$rpc_url" >/dev/null 2>&1; then
-        echo "DEBUG: RPC $rpc_url is not reachable" >&2
+        echo "[DEBUG]: RPC $rpc_url is not reachable" >&2
         return 1
     fi
     
@@ -149,20 +149,20 @@ _fund_ephemeral_account() {
     target_balance=$(cast balance --rpc-url "$rpc_url" "$target_address")
     local threshold="100000000000000000"  # 0.1 ETH in wei
     
-    echo "DEBUG: Target address balance: $target_balance" >&2
-    echo "DEBUG: Funding threshold: $threshold" >&2
+    echo "[DEBUG]: Target address balance: $target_balance" >&2
+    echo "[DEBUG]: Funding threshold: $threshold" >&2
     
     if [[ -n "$target_balance" && "$target_balance" != "0" ]]; then
         # Use bc for comparison if available, otherwise use bash arithmetic
         if command -v bc >/dev/null 2>&1; then
             if [[ $(echo "$target_balance > $threshold" | bc) -eq 1 ]]; then
-                echo "DEBUG: Target address already has sufficient balance ($target_balance > $threshold), skipping funding" >&2
+                echo "[DEBUG]: Target address already has sufficient balance ($target_balance > $threshold), skipping funding" >&2
                 return 0
             fi
         else
             # Fallback to bash arithmetic for smaller numbers
             if [[ "$target_balance" -gt "$threshold" ]]; then
-                echo "DEBUG: Target address already has sufficient balance ($target_balance > $threshold), skipping funding" >&2
+                echo "[DEBUG]: Target address already has sufficient balance ($target_balance > $threshold), skipping funding" >&2
                 return 0
             fi
         fi
@@ -170,15 +170,15 @@ _fund_ephemeral_account() {
     
     local funding_address
     funding_address=$(cast wallet address --private-key "$funding_private_key")
-    echo "DEBUG: Funding from address: $funding_address" >&2
+    echo "[DEBUG]: Funding from address: $funding_address" >&2
     
     # Check balance of funding account
     local balance
     balance=$(cast balance --rpc-url "$rpc_url" "$funding_address")
-    echo "DEBUG: Funding account balance: $balance" >&2
+    echo "[DEBUG]: Funding account balance: $balance" >&2
     
     if [[ "$balance" == "0" ]]; then
-        echo "DEBUG: Funding account has zero balance" >&2
+        echo "[DEBUG]: Funding account has zero balance" >&2
         return 1
     fi
     
@@ -186,11 +186,11 @@ _fund_ephemeral_account() {
     local tx_output
     if tx_output=$(cast send --rpc-url "$rpc_url" --private-key "$funding_private_key" \
          "$target_address" --value "$amount" 2>&1); then
-        echo "DEBUG: Successfully funded $target_address" >&2
+        echo "[DEBUG]: Successfully funded $target_address" >&2
         return 0
     else
-        echo "DEBUG: Failed to fund $target_address" >&2
-        echo "DEBUG: Transaction error: $tx_output" >&2
+        echo "[DEBUG]: Failed to fund $target_address" >&2
+        echo "[DEBUG]: Transaction error: $tx_output" >&2
         return 1
     fi
 }
@@ -261,18 +261,18 @@ _setup_token_for_ephemeral_account() {
     local rpc_url="$4"
     local bridge_addr="$5"
     
-    echo "DEBUG: Setting up token $token_type for $target_address" >&2
+    echo "[DEBUG]: Setting up token $token_type for $target_address" >&2
     
     case "$token_type" in
         "Buggy"|"LocalERC20")
             local token_addr
             token_addr=$(_get_token_address "$token_type")
-            echo "DEBUG: Token address for $token_type: $token_addr" >&2
+            echo "[DEBUG]: Token address for $token_type: $token_addr" >&2
             
             # Check if target address already has sufficient balance
             local current_balance
             if current_balance=$(cast call --rpc-url "$rpc_url" "$token_addr" 'balanceOf(address)(uint256)' "$target_address" 2>/dev/null); then
-                echo "DEBUG: Current token balance for $target_address: $current_balance" >&2
+                echo "[DEBUG]: Current token balance for $target_address: $current_balance" >&2
                 
                 # Define minimum required balance (use the requested amount as threshold)
                 local required_balance="$amount"
@@ -303,16 +303,16 @@ _setup_token_for_ephemeral_account() {
                     local current_length=${#current_balance}
                     local required_length=${#required_balance}
                     
-                    echo "DEBUG: Comparing balance lengths - current: $current_length, required: $required_length" >&2
+                    echo "[DEBUG]: Comparing balance lengths - current: $current_length, required: $required_length" >&2
                     # shellcheck disable=SC2071
                     if [[ $current_length -gt $required_length ]] || \
                        [[ $current_length -eq $required_length && "$current_balance" > "$required_balance" ]]; then
                         has_sufficient_balance=true
-                        echo "DEBUG: Large number comparison: sufficient balance detected" >&2
+                        echo "[DEBUG]: Large number comparison: sufficient balance detected" >&2
                     elif [[ "$token_type" == "Buggy" && $current_length -ge 75 ]]; then
                         # For Buggy token, if we have a very large number (75+ digits), it's probably sufficient
                         has_sufficient_balance=true
-                        echo "DEBUG: Buggy token has very large balance (${current_length} digits), considering sufficient" >&2
+                        echo "[DEBUG]: Buggy token has very large balance (${current_length} digits), considering sufficient" >&2
                     fi
                 else
                     # For normal amounts, use bc if available, otherwise bash arithmetic
@@ -343,11 +343,11 @@ _setup_token_for_ephemeral_account() {
                 fi
                 
                 if $has_sufficient_balance; then
-                    echo "DEBUG: Target address already has sufficient $token_type balance ($current_balance >= $required_balance), skipping minting" >&2
+                    echo "[DEBUG]: Target address already has sufficient $token_type balance ($current_balance >= $required_balance), skipping minting" >&2
                     return 0
                 fi
             else
-                echo "DEBUG: Could not check token balance, proceeding with minting" >&2
+                echo "[DEBUG]: Could not check token balance, proceeding with minting" >&2
             fi
             
             # For Max amount with LocalERC20, use a large but safe amount instead of max-uint
@@ -355,30 +355,30 @@ _setup_token_for_ephemeral_account() {
             if [[ "$amount" == "$(cast max-uint)" && "$token_type" == "LocalERC20" ]]; then
                 # Use 1 billion tokens instead of max-uint to avoid overflow
                 mint_amount="1000000000000000000000000000"  # 1 billion tokens (1e27)
-                echo "DEBUG: Using safe amount $mint_amount instead of max-uint for LocalERC20" >&2
+                echo "[DEBUG]: Using safe amount $mint_amount instead of max-uint for LocalERC20" >&2
             fi
             
-            echo "DEBUG: Minting $mint_amount of $token_type to $target_address" >&2
+            echo "[DEBUG]: Minting $mint_amount of $token_type to $target_address" >&2
             
             # Mint tokens with timeout (no nonce management needed for sequential execution)
             local mint_output
             if mint_output=$(cast send --rpc-url "$rpc_url" --private-key "$l1_private_key" \
                 "$token_addr" 'mint(address,uint256)' "$target_address" "$mint_amount" 2>&1); then
-                echo "DEBUG: Successfully minted $token_type tokens" >&2
+                echo "[DEBUG]: Successfully minted $token_type tokens" >&2
                 return 0
             else
-                echo "DEBUG: Failed to mint $token_type tokens" >&2
-                echo "DEBUG: Mint error: $mint_output" >&2
+                echo "[DEBUG]: Failed to mint $token_type tokens" >&2
+                echo "[DEBUG]: Mint error: $mint_output" >&2
                 return 1
             fi
             ;;
         "GasToken")
-            echo "DEBUG: Minting GasToken to $target_address" >&2
+            echo "[DEBUG]: Minting GasToken to $target_address" >&2
             
             # Check if target address already has sufficient GasToken balance
             local current_balance
             if current_balance=$(cast call --rpc-url "$rpc_url" "$gas_token_address" 'balanceOf(address)(uint256)' "$target_address" 2>/dev/null); then
-                echo "DEBUG: Current GasToken balance for $target_address: $current_balance" >&2
+                echo "[DEBUG]: Current GasToken balance for $target_address: $current_balance" >&2
                 
                 # Define minimum required balance
                 local required_balance="$amount"
@@ -407,7 +407,7 @@ _setup_token_for_ephemeral_account() {
                 fi
                 
                 if $has_sufficient_balance; then
-                    echo "DEBUG: Target address already has sufficient GasToken balance, skipping minting" >&2
+                    echo "[DEBUG]: Target address already has sufficient GasToken balance, skipping minting" >&2
                     return 0
                 fi
             fi
@@ -416,26 +416,26 @@ _setup_token_for_ephemeral_account() {
             local mint_amount="$amount"
             if [[ "$amount" == "$(cast max-uint)" ]]; then
                 mint_amount="1000000000000000000000000000"  # 1 billion tokens (1e27)
-                echo "DEBUG: Using safe amount $mint_amount instead of max-uint for GasToken" >&2
+                echo "[DEBUG]: Using safe amount $mint_amount instead of max-uint for GasToken" >&2
             fi
             
-            echo "DEBUG: Minting $mint_amount GasToken to $target_address" >&2
+            echo "[DEBUG]: Minting $mint_amount GasToken to $target_address" >&2
             
             # Mint GasToken with timeout
             local mint_output
             if mint_output=$(cast send --rpc-url "$rpc_url" --private-key "$l1_private_key" \
                 "$gas_token_address" 'mint(address,uint256)' "$target_address" "$mint_amount" 2>&1); then
-                echo "DEBUG: Successfully minted GasToken" >&2
+                echo "[DEBUG]: Successfully minted GasToken" >&2
                 return 0
             else
-                echo "DEBUG: Failed to mint GasToken" >&2
-                echo "DEBUG: GasToken mint error: $mint_output" >&2
+                echo "[DEBUG]: Failed to mint GasToken" >&2
+                echo "[DEBUG]: GasToken mint error: $mint_output" >&2
                 return 1
             fi
             ;;
         "POL")
-            echo "DEBUG: Transferring $amount POL to $target_address" >&2
-            echo "DEBUG: POL address: $pol_address" >&2
+            echo "[DEBUG]: Transferring $amount POL to $target_address" >&2
+            echo "[DEBUG]: POL address: $pol_address" >&2
             
             # For POL transfers with max amount, use a safe amount instead
             local transfer_amount="$amount"
@@ -446,11 +446,11 @@ _setup_token_for_ephemeral_account() {
                 if [[ -n "$pol_balance" && "$pol_balance" != "0" ]]; then
                     # Use 90% of available balance to avoid transfer amount exceeds balance error
                     transfer_amount=$((pol_balance * 9 / 10))
-                    echo "DEBUG: Using safe transfer amount $transfer_amount (90% of available $pol_balance) instead of max-uint for POL" >&2
+                    echo "[DEBUG]: Using safe transfer amount $transfer_amount (90% of available $pol_balance) instead of max-uint for POL" >&2
                 else
                     # Fallback to a reasonable amount if balance check fails
                     transfer_amount="1000000000000000000000000000"  # 1 billion tokens
-                    echo "DEBUG: Using fallback amount $transfer_amount for POL transfer" >&2
+                    echo "[DEBUG]: Using fallback amount $transfer_amount for POL transfer" >&2
                 fi
             fi
             
@@ -458,20 +458,20 @@ _setup_token_for_ephemeral_account() {
             local pol_output
             if pol_output=$(cast send --rpc-url "$rpc_url" --private-key "$l1_private_key" \
                 "$pol_address" 'transfer(address,uint256)' "$target_address" "$transfer_amount" 2>&1); then
-                echo "DEBUG: Successfully transferred POL tokens" >&2
+                echo "[DEBUG]: Successfully transferred POL tokens" >&2
                 return 0
             else
-                echo "DEBUG: Failed to transfer POL tokens" >&2
-                echo "DEBUG: POL transfer error: $pol_output" >&2
+                echo "[DEBUG]: Failed to transfer POL tokens" >&2
+                echo "[DEBUG]: POL transfer error: $pol_output" >&2
                 return 1
             fi
             ;;
         "NativeEther"|"WETH")
-            echo "DEBUG: Skipping token setup for $token_type (native token or special handling)" >&2
+            echo "[DEBUG]: Skipping token setup for $token_type (native token or special handling)" >&2
             return 0
             ;;
         *)
-            echo "DEBUG: Unknown token type $token_type, skipping" >&2
+            echo "[DEBUG]: Unknown token type $token_type, skipping" >&2
             return 0
             ;;
     esac
@@ -485,11 +485,11 @@ _approve_token_for_ephemeral_account() {
     local rpc_url="$4"
     local bridge_addr="$5"
     
-    echo "DEBUG: Approving $token_type tokens for bridge" >&2
+    echo "[DEBUG]: Approving $token_type tokens for bridge" >&2
     
     # Skip approval for native tokens and special cases
     if [[ "$token_type" == "NativeEther" || "$token_type" == "WETH" ]]; then
-        echo "DEBUG: Skipping approval for $token_type (native token or special handling)" >&2
+        echo "[DEBUG]: Skipping approval for $token_type (native token or special handling)" >&2
         return 0
     fi
     
@@ -498,23 +498,23 @@ _approve_token_for_ephemeral_account() {
     
     # Validate token address
     if [[ "$token_addr" == "0x0000000000000000000000000000000000000000" ]]; then
-        echo "DEBUG: Skipping approval for zero address token $token_type" >&2
+        echo "[DEBUG]: Skipping approval for zero address token $token_type" >&2
         return 0
     fi
     
     local ephemeral_address
     ephemeral_address=$(cast wallet address --private-key "$ephemeral_private_key")
     
-    echo "DEBUG: Approving $amount of token $token_addr for bridge $bridge_addr" >&2
-    echo "DEBUG: Approval from ephemeral address: $ephemeral_address" >&2
+    echo "[DEBUG]: Approving $amount of token $token_addr for bridge $bridge_addr" >&2
+    echo "[DEBUG]: Approval from ephemeral address: $ephemeral_address" >&2
     
     # Check if ephemeral account has native tokens for gas
     local ephemeral_balance
     ephemeral_balance=$(cast balance --rpc-url "$rpc_url" "$ephemeral_address")
-    echo "DEBUG: Ephemeral account native balance: $ephemeral_balance" >&2
+    echo "[DEBUG]: Ephemeral account native balance: $ephemeral_balance" >&2
     
     if [[ "$ephemeral_balance" == "0" ]]; then
-        echo "DEBUG: Ephemeral account has no native tokens for gas fees" >&2
+        echo "[DEBUG]: Ephemeral account has no native tokens for gas fees" >&2
         return 1
     fi
     
@@ -522,16 +522,16 @@ _approve_token_for_ephemeral_account() {
     local code_size
     code_size=$(cast code --rpc-url "$rpc_url" "$token_addr" | wc -c)
     if [[ $code_size -le 2 ]]; then  # "0x" is 2 characters
-        echo "DEBUG: Token contract $token_addr has no code, skipping approval" >&2
+        echo "[DEBUG]: Token contract $token_addr has no code, skipping approval" >&2
         return 0
     fi
     
     # Check token balance before approval
     local token_balance
     if token_balance=$(cast call --rpc-url "$rpc_url" "$token_addr" 'balanceOf(address)(uint256)' "$ephemeral_address" 2>/dev/null); then
-        echo "DEBUG: Ephemeral account token balance: $token_balance" >&2
+        echo "[DEBUG]: Ephemeral account token balance: $token_balance" >&2
     else
-        echo "DEBUG: Failed to check token balance, proceeding with approval anyway" >&2
+        echo "[DEBUG]: Failed to check token balance, proceeding with approval anyway" >&2
     fi
     
     # Use the same safe amount logic for approval
@@ -540,16 +540,16 @@ _approve_token_for_ephemeral_account() {
         case "$token_type" in
             "LocalERC20"|"GasToken")
                 approve_amount="1000000000000000000000000000"  # 1 billion tokens (1e27)
-                echo "DEBUG: Using safe approval amount $approve_amount instead of max-uint for $token_type" >&2
+                echo "[DEBUG]: Using safe approval amount $approve_amount instead of max-uint for $token_type" >&2
                 ;;
             "POL")
                 # Use the actual token balance for approval
                 if [[ -n "$token_balance" && "$token_balance" != "0" ]]; then
                     approve_amount="$token_balance"
-                    echo "DEBUG: Using token balance $approve_amount for POL approval" >&2
+                    echo "[DEBUG]: Using token balance $approve_amount for POL approval" >&2
                 else
                     approve_amount="1000000000000000000000000000"  # 1 billion tokens fallback
-                    echo "DEBUG: Using fallback approval amount $approve_amount for POL" >&2
+                    echo "[DEBUG]: Using fallback approval amount $approve_amount for POL" >&2
                 fi
                 ;;
             *)
@@ -562,11 +562,11 @@ _approve_token_for_ephemeral_account() {
     local approve_output
     if approve_output=$(cast send --rpc-url "$rpc_url" --private-key "$ephemeral_private_key" \
         "$token_addr" 'approve(address,uint256)' "$bridge_addr" "$approve_amount" 2>&1); then
-        echo "DEBUG: Successfully approved tokens" >&2
+        echo "[DEBUG]: Successfully approved tokens" >&2
         return 0
     else
-        echo "DEBUG: Failed to approve tokens" >&2
-        echo "DEBUG: Approval error: $approve_output" >&2
+        echo "[DEBUG]: Failed to approve tokens" >&2
+        echo "[DEBUG]: Approval error: $approve_output" >&2
         return 1
     fi
 }
@@ -646,7 +646,7 @@ _add_metadata_to_command() {
             local temp_file="/tmp/huge_data_${test_index}.hex"
             # Create the file with proper hex data - add error handling and redirect stderr
             if ! (dd if=/dev/zero bs=1 count=48500 2>/dev/null | xxd -p | tr -d "\n" > "$temp_file"); then
-                echo "DEBUG: Failed to create huge metadata file, using alternative method" >&2
+                echo "[DEBUG]: Failed to create huge metadata file, using alternative method" >&2
                 # Alternative method using printf
                 printf '%*s' 97000 '' | tr ' ' '0' > "$temp_file"
             fi
@@ -658,14 +658,14 @@ _add_metadata_to_command() {
             if [[ "$token_type" == "POL" ]]; then
                 # Use smaller metadata size for POL to avoid memory/gas issues
                 if ! (dd if=/dev/zero bs=1 count=65000 2>/dev/null | xxd -p | tr -d "\n" > "$temp_file"); then
-                    echo "DEBUG: Failed to create max metadata file for POL, using alternative method" >&2
+                    echo "[DEBUG]: Failed to create max metadata file for POL, using alternative method" >&2
                     printf '%*s' 130000 '' | tr ' ' '0' > "$temp_file"
                 fi
-                echo "DEBUG: Using reduced metadata size for POL token" >&2
+                echo "[DEBUG]: Using reduced metadata size for POL token" >&2
             else
                 # Normal max size for other tokens
                 if ! (dd if=/dev/zero bs=1 count=130784 2>/dev/null | xxd -p | tr -d "\n" > "$temp_file"); then
-                    echo "DEBUG: Failed to create max metadata file, using alternative method" >&2
+                    echo "[DEBUG]: Failed to create max metadata file, using alternative method" >&2
                     printf '%*s' 261569 '' | tr ' ' '0' > "$temp_file"
                 fi
             fi
@@ -728,7 +728,7 @@ _setup_amount_and_add_to_command() {
             elif [[ "$token_type" == "POL" && "$metadata_type" == "Max" ]]; then
                 # Special case: POL with Max amount AND Max metadata - use much smaller amount
                 echo "$command --value 100000000000000000000000 --gas-limit $gas_limit_value"
-                echo "DEBUG: Using reduced bridge amount for POL Max+Max combination" >&2
+                echo "[DEBUG]: Using reduced bridge amount for POL Max+Max combination" >&2
             elif [[ "$token_type" == "LocalERC20" || "$token_type" == "POL" ]]; then
                 # Use the safe amount for LocalERC20 and POL (normal cases)
                 local max_gas_limit=$((gas_limit_value * 2))
@@ -755,7 +755,7 @@ _setup_single_test_account() {
     local scenario="$2"
     local bridge_direction="${3:-L1_TO_L2}"  # Default to L1->L2 for backward compatibility
     
-    echo "DEBUG: Setting up account for test $test_index (direction: $bridge_direction)" >&2
+    echo "[DEBUG]: Setting up account for test $test_index (direction: $bridge_direction)" >&2
     
     # Extract scenario parameters
     local test_token
@@ -781,7 +781,7 @@ _setup_single_test_account() {
         dest_bridge_addr="$l1_bridge_addr"
         dest_private_key="$l1_private_key"
         
-        echo "DEBUG: Configured for L2->L1 bridge setup" >&2
+        echo "[DEBUG]: Configured for L2->L1 bridge setup" >&2
     else
         # Bridge from L1 to L2 (default) - setup tokens on L1 (source)
         source_rpc_url="$l1_rpc_url"
@@ -794,7 +794,7 @@ _setup_single_test_account() {
         dest_bridge_addr="$l2_bridge_addr"
         dest_private_key="$l2_private_key"
         
-        echo "DEBUG: Configured for L1->L2 bridge setup" >&2
+        echo "[DEBUG]: Configured for L1->L2 bridge setup" >&2
     fi
     
     # Generate ephemeral account
@@ -805,26 +805,26 @@ _setup_single_test_account() {
     local ephemeral_address
     ephemeral_address=$(echo "$ephemeral_data" | cut -d' ' -f2)
     
-    echo "DEBUG: Generated ephemeral account for test $test_index: $ephemeral_address" >&2
-    echo "DEBUG: Private key for ephemeral account $test_index: $ephemeral_private_key" >&2
+    echo "[DEBUG]: Generated ephemeral account for test $test_index: $ephemeral_address" >&2
+    echo "[DEBUG]: Private key for ephemeral account $test_index: $ephemeral_private_key" >&2
     
     # Test if ephemeral_private_key is valid
     if [[ -z "$ephemeral_private_key" || "$ephemeral_private_key" == "0x" ]]; then
-        echo "DEBUG: Failed to generate ephemeral private key for test $test_index" >&2
+        echo "[DEBUG]: Failed to generate ephemeral private key for test $test_index" >&2
         return 1
     fi
     
     # Fund ephemeral account with native tokens on source network (where bridging happens from)
-    echo "DEBUG: Funding source network account for test $test_index ($bridge_direction)" >&2
+    echo "[DEBUG]: Funding source network account for test $test_index ($bridge_direction)" >&2
     if ! _fund_ephemeral_account "$ephemeral_address" "$source_rpc_url" "$source_private_key" "100000000000000000"; then
-        echo "DEBUG: Failed to fund source network account for test $test_index" >&2
+        echo "[DEBUG]: Failed to fund source network account for test $test_index" >&2
         return 1
     fi
     
     # Fund ephemeral account with native tokens on destination network (for claims later)
-    echo "DEBUG: Funding destination network account for test $test_index ($bridge_direction)" >&2
+    echo "[DEBUG]: Funding destination network account for test $test_index ($bridge_direction)" >&2
     if ! _fund_ephemeral_account "$ephemeral_address" "$dest_rpc_url" "$dest_private_key" "10000000000000000"; then
-        echo "DEBUG: Failed to fund destination network account for test $test_index" >&2
+        echo "[DEBUG]: Failed to fund destination network account for test $test_index" >&2
         return 1
     fi
     
@@ -835,7 +835,7 @@ _setup_single_test_account() {
         if [[ "$test_token" == "POL" && "$test_meta_data" == "Max" ]]; then
             # Use even smaller amount for this problematic combination
             amount_for_setup="100000000000000000000000"
-            echo "DEBUG: Using reduced amount $amount_for_setup for POL Max+Max combination" >&2
+            echo "[DEBUG]: Using reduced amount $amount_for_setup for POL Max+Max combination" >&2
         elif [[ "$test_token" == "LocalERC20" || "$test_token" == "POL" ]]; then
             amount_for_setup="1000000000000000000000000000"
         else
@@ -843,22 +843,22 @@ _setup_single_test_account() {
         fi
     fi
     
-    echo "DEBUG: Setting up tokens for test $test_index on source network (token: $test_token, amount: $amount_for_setup)" >&2
+    echo "[DEBUG]: Setting up tokens for test $test_index on source network (token: $test_token, amount: $amount_for_setup)" >&2
     if ! _setup_token_for_ephemeral_account "$ephemeral_address" "$test_token" "$amount_for_setup" "$source_rpc_url" "$source_bridge_addr"; then
-        echo "DEBUG: Failed to setup tokens for test $test_index on source network" >&2
+        echo "[DEBUG]: Failed to setup tokens for test $test_index on source network" >&2
         return 1
     fi
     
     # Small delay to let transaction propagate
     sleep 0.5
     
-    echo "DEBUG: Approving tokens for test $test_index on source network" >&2
+    echo "[DEBUG]: Approving tokens for test $test_index on source network" >&2
     if ! _approve_token_for_ephemeral_account "$ephemeral_private_key" "$test_token" "$amount_for_setup" "$source_rpc_url" "$source_bridge_addr"; then
-        echo "DEBUG: Failed to approve tokens for test $test_index on source network" >&2
+        echo "[DEBUG]: Failed to approve tokens for test $test_index on source network" >&2
         return 1
     fi
     
-    echo "DEBUG: Successfully set up account for test $test_index ($bridge_direction)" >&2
+    echo "[DEBUG]: Successfully set up account for test $test_index ($bridge_direction)" >&2
     return 0
 }
 
@@ -878,54 +878,54 @@ _validate_bridge_error() {
     
     # Check for "already claimed" patterns first - these should generally be treated as success
     if echo "$output" | grep -q -E "(already been claimed|AlreadyClaimedError|the claim transaction has already been claimed)"; then
-        echo "DEBUG: Found 'already claimed' pattern - usually indicates success" >&2
+        echo "[DEBUG]: Found 'already claimed' pattern - usually indicates success" >&2
         return 0
     fi
-    echo "DEBUG: Validating bridge error - Expected: $expected_result" >&2
-    echo "DEBUG: Bridge output: $output" >&2
+    echo "[DEBUG]: Validating bridge error - Expected: $expected_result" >&2
+    echo "[DEBUG]: Bridge output: $output" >&2
     
     # Check if expected_result_claim is an array or a single string
     if [[ "$expected_result" =~ ^\[.*\]$ ]]; then
         # Handle array of expected results
-        echo "DEBUG: Processing array of expected results" >&2
+        echo "[DEBUG]: Processing array of expected results" >&2
         local match_found=false
         while read -r expected_error; do
             expected_error=$(echo "$expected_error" | jq -r '.')
-            echo "DEBUG: Checking for expected error: $expected_error" >&2
+            echo "[DEBUG]: Checking for expected error: $expected_error" >&2
             
             # Special handling for "Success" in array
             if [[ "$expected_error" == "Success" ]]; then
-                echo "DEBUG: Found 'Success' in expected array - this should be handled in main logic" >&2
+                echo "[DEBUG]: Found 'Success' in expected array - this should be handled in main logic" >&2
                 match_found=true
                 break
             elif _check_error_pattern "$expected_error" "$output"; then
-                echo "DEBUG: Found matching error pattern: $expected_error" >&2
+                echo "[DEBUG]: Found matching error pattern: $expected_error" >&2
                 match_found=true
                 break
             fi
         done < <(echo "$expected_result" | jq -c '.[]')
         
         if $match_found; then
-            echo "DEBUG: Match found in array validation" >&2
+            echo "[DEBUG]: Match found in array validation" >&2
             return 0
         else
-            echo "DEBUG: No match found in array validation" >&2
+            echo "[DEBUG]: No match found in array validation" >&2
             return 1
         fi
     else
         # Handle single expected error
         local expected_error
         expected_error=$(echo "$expected_result" | jq -r '.')
-        echo "DEBUG: Processing single expected result: $expected_error" >&2
+        echo "[DEBUG]: Processing single expected result: $expected_error" >&2
         
         if [[ "$expected_error" == "Success" ]]; then
-            echo "DEBUG: Single 'Success' expected" >&2
+            echo "[DEBUG]: Single 'Success' expected" >&2
             return 0  # Success is always valid
         elif _check_error_pattern "$expected_error" "$output"; then
-            echo "DEBUG: Single error pattern matched" >&2
+            echo "[DEBUG]: Single error pattern matched" >&2
             return 0
         else
-            echo "DEBUG: Single error pattern not matched" >&2
+            echo "[DEBUG]: Single error pattern not matched" >&2
             return 1
         fi
     fi
@@ -936,29 +936,29 @@ _check_error_pattern() {
     local expected_error="$1"
     local output="$2"
     
-    echo "DEBUG: Checking error pattern '$expected_error' in output" >&2
+    echo "[DEBUG]: Checking error pattern '$expected_error' in output" >&2
     
     # Handle different error patterns
     if [[ "$expected_error" =~ ^oversized\ data ]]; then
         if echo "$output" | grep -q "oversized data: transaction size [0-9]\+, limit 131072"; then
-            echo "DEBUG: Matched oversized data pattern" >&2
+            echo "[DEBUG]: Matched oversized data pattern" >&2
             return 0
         fi
     elif [[ "$expected_error" =~ ^0x[0-9a-fA-F]+$ ]]; then
         # Handle hex error codes (like 0x23d72133)
         if echo "$output" | grep -q "$expected_error"; then
-            echo "DEBUG: Matched hex error code: $expected_error" >&2
+            echo "[DEBUG]: Matched hex error code: $expected_error" >&2
             return 0
         fi
     else
         # Handle general string patterns
         if echo "$output" | grep -q "$expected_error"; then
-            echo "DEBUG: Matched general error pattern: $expected_error" >&2
+            echo "[DEBUG]: Matched general error pattern: $expected_error" >&2
             return 0
         fi
     fi
     
-    echo "DEBUG: No pattern match found for: $expected_error" >&2
+    echo "[DEBUG]: No pattern match found for: $expected_error" >&2
     return 1
 }
 
@@ -969,7 +969,7 @@ _run_single_bridge_test() {
     local bridge_direction="${3:-L1_TO_L2}"  # Default to L1->L2 for backward compatibility
     local result_file="/tmp/test_result_${test_index}.txt"
     
-    echo "DEBUG: Starting bridge test $test_index (direction: $bridge_direction)" >&2
+    echo "[DEBUG]: Starting bridge test $test_index (direction: $bridge_direction)" >&2
     
     # Extract scenario parameters
     local test_bridge_type
@@ -1011,7 +1011,7 @@ _run_single_bridge_test() {
         claim_bridge_addr="$l1_bridge_addr"
         claim_private_key="$l1_private_key"
         
-        echo "DEBUG: Configured for L2->L1 bridge" >&2
+        echo "[DEBUG]: Configured for L2->L1 bridge" >&2
     else
         # Bridge from L1 to L2 (default)
         source_rpc_url="$l1_rpc_url"
@@ -1029,10 +1029,10 @@ _run_single_bridge_test() {
         claim_bridge_addr="$l2_bridge_addr"
         claim_private_key="$l2_private_key"
         
-        echo "DEBUG: Configured for L1->L2 bridge" >&2
+        echo "[DEBUG]: Configured for L1->L2 bridge" >&2
     fi
     
-    echo "DEBUG: Test $test_index - Token: $test_token, Amount: $test_amount, Metadata: $test_meta_data" >&2
+    echo "[DEBUG]: Test $test_index - Token: $test_token, Amount: $test_amount, Metadata: $test_meta_data" >&2
     
     # Get ephemeral account (already set up)
     local ephemeral_data
@@ -1042,30 +1042,30 @@ _run_single_bridge_test() {
     local ephemeral_address
     ephemeral_address=$(echo "$ephemeral_data" | cut -d' ' -f2)
     
-    echo "DEBUG: Using ephemeral account for test $test_index: $ephemeral_address" >&2
+    echo "[DEBUG]: Using ephemeral account for test $test_index: $ephemeral_address" >&2
     
     # Pre-create metadata files if needed
     if [[ "$test_meta_data" == "Huge" ]]; then
         local temp_file="/tmp/huge_data_${test_index}.hex"
-        echo "DEBUG: Creating huge metadata file: $temp_file" >&2
+        echo "[DEBUG]: Creating huge metadata file: $temp_file" >&2
         xxd -p /dev/zero | tr -d "\n" | head -c 97000 > "$temp_file"
         if [[ ! -f "$temp_file" ]]; then
-            echo "DEBUG: Failed to create huge metadata file" >&2
+            echo "[DEBUG]: Failed to create huge metadata file" >&2
             echo "TEST_$test_index|FAIL|N/A|Failed to create metadata file" > "$result_file"
             return 1
         fi
     elif [[ "$test_meta_data" == "Max" ]]; then
         local temp_file="/tmp/max_data_${test_index}.hex"
-        echo "DEBUG: Creating max metadata file: $temp_file" >&2
+        echo "[DEBUG]: Creating max metadata file: $temp_file" >&2
         # Special handling for POL with Max metadata
         if [[ "$test_token" == "POL" ]]; then
             xxd -p /dev/zero | tr -d "\n" | head -c 130000 > "$temp_file"  # Reduced size for POL
-            echo "DEBUG: Created reduced max metadata file for POL: $(wc -c < "$temp_file") bytes" >&2
+            echo "[DEBUG]: Created reduced max metadata file for POL: $(wc -c < "$temp_file") bytes" >&2
         else
             xxd -p /dev/zero | tr -d "\n" | head -c 261569 > "$temp_file"
         fi
         if [[ ! -f "$temp_file" ]]; then
-            echo "DEBUG: Failed to create max metadata file" >&2
+            echo "[DEBUG]: Failed to create max metadata file" >&2
             echo "TEST_$test_index|FAIL|N/A|Failed to create metadata file" > "$result_file"
             return 1
         fi
@@ -1094,7 +1094,7 @@ _run_single_bridge_test() {
     # Add metadata with test_index and token_type parameters
     bridge_command=$(_add_metadata_to_command "$bridge_command" "$test_meta_data" "$test_index" "$test_token")
     if [[ $? -ne 0 ]]; then
-        echo "DEBUG: Failed to add metadata to command" >&2
+        echo "[DEBUG]: Failed to add metadata to command" >&2
         echo "TEST_$test_index|FAIL|N/A|Failed to add metadata" > "$result_file"
         return 1
     fi
@@ -1102,7 +1102,7 @@ _run_single_bridge_test() {
     # Add force update flag
     bridge_command=$(_add_force_update_to_command "$bridge_command" "$test_force_update")
     if [[ $? -ne 0 ]]; then
-        echo "DEBUG: Failed to add force update to command" >&2
+        echo "[DEBUG]: Failed to add force update to command" >&2
         echo "TEST_$test_index|FAIL|N/A|Failed to add force update flag" > "$result_file"
         return 1
     fi
@@ -1110,7 +1110,7 @@ _run_single_bridge_test() {
     # Setup amount and add to command (now with metadata parameter)
     bridge_command=$(_setup_amount_and_add_to_command "$bridge_command" "$test_amount" "$ephemeral_private_key" "$test_token" "$test_index" "$test_meta_data" "$base_gas_limit")
     if [[ $? -ne 0 ]]; then
-        echo "DEBUG: Failed to add amount to command" >&2
+        echo "[DEBUG]: Failed to add amount to command" >&2
         echo "TEST_$test_index|FAIL|N/A|Failed to add amount" > "$result_file"
         return 1
     fi
@@ -1135,7 +1135,7 @@ _run_single_bridge_test() {
         bridge_command="$bridge_command $base_gas_limit"
     fi
     
-    echo "DEBUG: Executing bridge command for test $test_index: $bridge_command" >&2
+    echo "[DEBUG]: Executing bridge command for test $test_index: $bridge_command" >&2
     
     # Execute the bridge command with longer timeout for problematic combinations
     local timeout_duration=$global_timeout
@@ -1148,45 +1148,45 @@ _run_single_bridge_test() {
     
     while [[ $bridge_attempt -lt $max_bridge_retries ]]; do
         bridge_attempt=$((bridge_attempt + 1))
-        echo "DEBUG: Bridge attempt $bridge_attempt for test $test_index" >&2
+        echo "[DEBUG]: Bridge attempt $bridge_attempt for test $test_index" >&2
         
         if bridge_output=$(timeout "$timeout_duration" bash -c "$bridge_command" 2>&1); then
             bridge_status=0
-            echo "DEBUG: Bridge command succeeded on attempt $bridge_attempt" >&2
+            echo "[DEBUG]: Bridge command succeeded on attempt $bridge_attempt" >&2
             break
         else
             bridge_status=$?
-            echo "DEBUG: Bridge attempt $bridge_attempt failed with status $bridge_status" >&2
-            echo "DEBUG: Bridge output: $bridge_output" >&2
+            echo "[DEBUG]: Bridge attempt $bridge_attempt failed with status $bridge_status" >&2
+            echo "[DEBUG]: Bridge output: $bridge_output" >&2
             
             # Check if this is a retryable error
             retry_bridge=false
             
             # Check for network/receipt timeout issues - these are retryable
             if echo "$bridge_output" | grep -q -E "(Wait timer for transaction receipt exceeded|not found|connection refused|timeout|network error)"; then
-                echo "DEBUG: Detected network/timeout error - this is retryable" >&2
+                echo "[DEBUG]: Detected network/timeout error - this is retryable" >&2
                 retry_bridge=true
             fi
             
             # Check for nonce issues - also retryable
             if echo "$bridge_output" | grep -q -E "(nonce too low|replacement transaction underpriced|already known)"; then
-                echo "DEBUG: Detected nonce/replacement error - this is retryable" >&2
+                echo "[DEBUG]: Detected nonce/replacement error - this is retryable" >&2
                 retry_bridge=true
             fi
             
             # Check for temporary RPC issues
             if echo "$bridge_output" | grep -q -E "(502 Bad Gateway|503 Service Unavailable|429 Too Many Requests|Internal server error)"; then
-                echo "DEBUG: Detected temporary RPC error - this is retryable" >&2
+                echo "[DEBUG]: Detected temporary RPC error - this is retryable" >&2
                 retry_bridge=true
             fi
             
             # If it's retryable and we haven't exhausted retries, continue
             if $retry_bridge && [[ $bridge_attempt -lt $max_bridge_retries ]]; then
-                echo "DEBUG: Retrying bridge operation after delay (attempt $bridge_attempt/$max_bridge_retries)" >&2
+                echo "[DEBUG]: Retrying bridge operation after delay (attempt $bridge_attempt/$max_bridge_retries)" >&2
                 
                 # For replacement transaction underpriced errors, increase gas price and limit
                 if echo "$bridge_output" | grep -q "replacement transaction underpriced"; then
-                    echo "DEBUG: Increasing gas price and limit for replacement transaction" >&2
+                    echo "[DEBUG]: Increasing gas price and limit for replacement transaction" >&2
                     
                     # Calculate gas price multiplier based on attempt (1.5x, 2x, 2.5x, etc.)
                     local gas_price_multiplier=$((bridge_attempt + 1))
@@ -1197,9 +1197,9 @@ _run_single_bridge_test() {
                     if current_gas_price=$(cast gas-price --rpc-url "$source_rpc_url" 2>/dev/null); then
                         # Increase gas price by multiplier + 20% buffer
                         local new_gas_price=$((current_gas_price * gas_price_multiplier * 12 / 10))
-                        echo "DEBUG: Setting gas price to $new_gas_price (${gas_price_multiplier}.2x current)" >&2
+                        echo "[DEBUG]: Setting gas price to $new_gas_price (${gas_price_multiplier}.2x current)" >&2
                     else
-                        echo "DEBUG: Could not get current gas price, using default escalation" >&2
+                        echo "[DEBUG]: Could not get current gas price, using default escalation" >&2
                         local new_gas_price=$((20000000000 * gas_price_multiplier))  # 20 gwei * multiplier
                     fi
                     
@@ -1208,7 +1208,7 @@ _run_single_bridge_test() {
                     if [[ "$bridge_command" =~ --gas-limit\ ([0-9]+) ]]; then
                         current_gas_limit="${BASH_REMATCH[1]}"
                         local new_gas_limit=$((current_gas_limit * gas_limit_multiplier))
-                        echo "DEBUG: Increasing gas limit from $current_gas_limit to $new_gas_limit" >&2
+                        echo "[DEBUG]: Increasing gas limit from $current_gas_limit to $new_gas_limit" >&2
                         
                         # Update the command with new gas limit
                         bridge_command=$(echo "$bridge_command" | sed "s/--gas-limit [0-9]*/--gas-limit $new_gas_limit/")
@@ -1216,14 +1216,14 @@ _run_single_bridge_test() {
                         # Add gas limit if not present
                         local base_gas_limit=$((3000000 * gas_limit_multiplier))
                         bridge_command="$bridge_command --gas-limit $base_gas_limit"
-                        echo "DEBUG: Added gas limit: $base_gas_limit" >&2
+                        echo "[DEBUG]: Added gas limit: $base_gas_limit" >&2
                     fi
                     
                     # Add gas price to command
                     bridge_command="$bridge_command --gas-price $new_gas_price"
-                    echo "DEBUG: Updated bridge command with higher gas: $bridge_command" >&2
+                    echo "[DEBUG]: Updated bridge command with higher gas: $bridge_command" >&2
                 elif echo "$bridge_output" | grep -q -E "(Wait timer for transaction receipt exceeded|not found)"; then
-                    echo "DEBUG: Network/timeout error detected, increasing gas for faster inclusion" >&2
+                    echo "[DEBUG]: Network/timeout error detected, increasing gas for faster inclusion" >&2
                     
                     # For network issues, also increase gas to get priority
                     local gas_multiplier=$((bridge_attempt + 1))
@@ -1233,7 +1233,7 @@ _run_single_bridge_test() {
                         local current_gas_limit="${BASH_REMATCH[1]}"
                         local new_gas_limit=$((current_gas_limit * gas_multiplier))
                         bridge_command=$(echo "$bridge_command" | sed "s/--gas-limit [0-9]*/--gas-limit $new_gas_limit/")
-                        echo "DEBUG: Increased gas limit to $new_gas_limit for faster inclusion" >&2
+                        echo "[DEBUG]: Increased gas limit to $new_gas_limit for faster inclusion" >&2
                     fi
                     
                     # Add higher gas price for network issues
@@ -1241,7 +1241,7 @@ _run_single_bridge_test() {
                     if current_gas_price=$(cast gas-price --rpc-url "$source_rpc_url" 2>/dev/null); then
                         local priority_gas_price=$((current_gas_price * gas_multiplier * 15 / 10))  # 1.5x * multiplier
                         bridge_command="$bridge_command --gas-price $priority_gas_price"
-                        echo "DEBUG: Added priority gas price: $priority_gas_price" >&2
+                        echo "[DEBUG]: Added priority gas price: $priority_gas_price" >&2
                     fi
                 fi
                 
@@ -1249,7 +1249,7 @@ _run_single_bridge_test() {
                 continue
             else
                 # Not retryable or exhausted retries
-                echo "DEBUG: Bridge operation failed permanently or exhausted retries" >&2
+                echo "[DEBUG]: Bridge operation failed permanently or exhausted retries" >&2
                 break
             fi
         fi
@@ -1257,94 +1257,94 @@ _run_single_bridge_test() {
     
     # Only do gas limit retry if the final attempt failed with gas issues
     if [[ $bridge_status -ne 0 ]]; then
-        echo "DEBUG: Bridge command failed with timeout or error status $bridge_status" >&2
+        echo "[DEBUG]: Bridge command failed with timeout or error status $bridge_status" >&2
         
         # Check if it's a gas limit issue and suggest retry with higher gas
         if echo "$bridge_output" | grep -q -E "(Perhaps try increasing the gas limit|insufficient gas|intrinsic gas too low|GasUsed=[0-9]+ cumulativeGasUsedForTx=)"; then
-            echo "DEBUG: Gas limit issue detected, removing gas limit to use automatic estimation" >&2
+            echo "[DEBUG]: Gas limit issue detected, removing gas limit to use automatic estimation" >&2
             
             # Remove the gas limit parameter entirely to let the system auto-estimate
             local retry_command
             retry_command=$(echo "$bridge_command" | sed 's/--gas-limit [0-9]* //g')
-            echo "DEBUG: Retrying without gas limit (auto-estimation): $retry_command" >&2
+            echo "[DEBUG]: Retrying without gas limit (auto-estimation): $retry_command" >&2
             
             if bridge_output=$(timeout "$timeout_duration" bash -c "$retry_command" 2>&1); then
                 bridge_status=0
-                echo "DEBUG: Retry without gas limit succeeded" >&2
+                echo "[DEBUG]: Retry without gas limit succeeded" >&2
             else
                 bridge_status=$?
-                echo "DEBUG: Retry without gas limit also failed" >&2
-                echo "DEBUG: Retry output: $bridge_output" >&2
+                echo "[DEBUG]: Retry without gas limit also failed" >&2
+                echo "[DEBUG]: Retry output: $bridge_output" >&2
                 
                 # If it still fails, check if it's a different error
                 if echo "$bridge_output" | grep -q -E "(insufficient gas|intrinsic gas too low|Perhaps try increasing the gas limit|GasUsed=[0-9]+)"; then
-                    echo "DEBUG: Still a gas issue even with auto-estimation - may be a block limit" >&2
+                    echo "[DEBUG]: Still a gas issue even with auto-estimation - may be a block limit" >&2
                 elif echo "$bridge_output" | grep -q "exceeds block gas limit"; then
-                    echo "DEBUG: Transaction exceeds block gas limit even with auto-estimation" >&2
+                    echo "[DEBUG]: Transaction exceeds block gas limit even with auto-estimation" >&2
                     # Check if this is an expected failure
                     if [[ "$expected_result_process" != "Success" ]]; then
-                        echo "DEBUG: Block gas limit error matches expected failure" >&2
+                        echo "[DEBUG]: Block gas limit error matches expected failure" >&2
                         bridge_status=0  # Treat as success if failure was expected
                     fi
                 else
-                    echo "DEBUG: Different error after removing gas limit" >&2
+                    echo "[DEBUG]: Different error after removing gas limit" >&2
                 fi
             fi
         # Add special handling for huge calldata scenarios that fail with network/timeout errors
         elif [[ "$test_meta_data" == "Huge" || "$test_meta_data" == "Max" ]] && \
             echo "$bridge_output" | grep -q -E "(Wait timer for transaction receipt exceeded|not found|replacement transaction underpriced)"; then
-            echo "DEBUG: Huge/Max calldata with network/timeout errors - likely gas estimation issue, removing gas limit" >&2
+            echo "[DEBUG]: Huge/Max calldata with network/timeout errors - likely gas estimation issue, removing gas limit" >&2
             
             # Remove the gas limit parameter entirely to let the system auto-estimate
             local retry_command
             retry_command=$(echo "$bridge_command" | sed 's/--gas-limit [0-9]* //g')
-            echo "DEBUG: Retrying huge/max calldata without gas limit (auto-estimation): $retry_command" >&2
+            echo "[DEBUG]: Retrying huge/max calldata without gas limit (auto-estimation): $retry_command" >&2
             
             if bridge_output=$(timeout "$timeout_duration" bash -c "$retry_command" 2>&1); then
                 bridge_status=0
-                echo "DEBUG: Retry without gas limit succeeded for huge/max calldata" >&2
+                echo "[DEBUG]: Retry without gas limit succeeded for huge/max calldata" >&2
             else
                 bridge_status=$?
-                echo "DEBUG: Retry without gas limit also failed for huge/max calldata" >&2
-                echo "DEBUG: Retry output: $bridge_output" >&2
+                echo "[DEBUG]: Retry without gas limit also failed for huge/max calldata" >&2
+                echo "[DEBUG]: Retry output: $bridge_output" >&2
                 
                 # Check if it's still a gas/block limit issue
                 if echo "$bridge_output" | grep -q -E "(insufficient gas|intrinsic gas too low|Perhaps try increasing the gas limit|GasUsed=[0-9]+)"; then
-                    echo "DEBUG: Still a gas issue even with auto-estimation for huge/max calldata" >&2
+                    echo "[DEBUG]: Still a gas issue even with auto-estimation for huge/max calldata" >&2
                 elif echo "$bridge_output" | grep -q "exceeds block gas limit"; then
-                    echo "DEBUG: Transaction exceeds block gas limit even with auto-estimation for huge/max calldata" >&2
+                    echo "[DEBUG]: Transaction exceeds block gas limit even with auto-estimation for huge/max calldata" >&2
                     # Check if this is an expected failure
                     if [[ "$expected_result_process" != "Success" ]]; then
-                        echo "DEBUG: Block gas limit error matches expected failure for huge/max calldata" >&2
+                        echo "[DEBUG]: Block gas limit error matches expected failure for huge/max calldata" >&2
                         bridge_status=0  # Treat as success if failure was expected
                     fi
                 elif echo "$bridge_output" | grep -q -E "(Wait timer for transaction receipt exceeded|not found)"; then
-                    echo "DEBUG: Still getting network/timeout errors even without gas limit - may be RPC issue" >&2
+                    echo "[DEBUG]: Still getting network/timeout errors even without gas limit - may be RPC issue" >&2
                 else
-                    echo "DEBUG: Different error after removing gas limit for huge/max calldata" >&2
+                    echo "[DEBUG]: Different error after removing gas limit for huge/max calldata" >&2
                 fi
             fi
         elif echo "$bridge_output" | grep -q "exceeds block gas limit"; then
-            echo "DEBUG: Transaction exceeds block gas limit - this is expected for some edge case tests" >&2
+            echo "[DEBUG]: Transaction exceeds block gas limit - this is expected for some edge case tests" >&2
             # For tests expecting to hit block gas limits, this might be the expected behavior
             # Check if this is an expected failure
             if [[ "$expected_result_process" != "Success" ]]; then
-                echo "DEBUG: Block gas limit error matches expected failure" >&2
+                echo "[DEBUG]: Block gas limit error matches expected failure" >&2
                 bridge_status=0  # Treat as success if failure was expected
             fi
         fi
     fi
     
-    echo "DEBUG: Bridge command completed for test $test_index with status $bridge_status" >&2
+    echo "[DEBUG]: Bridge command completed for test $test_index with status $bridge_status" >&2
     if [[ $bridge_status -ne 0 ]]; then
-        echo "DEBUG: Bridge output: $bridge_output" >&2
+        echo "[DEBUG]: Bridge output: $bridge_output" >&2
     fi
     
     local deposit_count=""
     if [[ $bridge_status -eq 0 ]]; then
-        echo "DEBUG: Bridge output: $bridge_output" >&2
+        echo "[DEBUG]: Bridge output: $bridge_output" >&2
         deposit_count=$(echo "$bridge_output" | awk '/depositCount=/ {gsub(/.*depositCount=/, ""); gsub(/\x1b\[[0-9;]*m/, ""); print}')
-        echo "DEBUG: Extracted deposit count: $deposit_count" >&2
+        echo "[DEBUG]: Extracted deposit count: $deposit_count" >&2
     fi
     
     local bridge_result="FAIL"
@@ -1360,36 +1360,36 @@ _run_single_bridge_test() {
         bridge_expects_success=true
     elif [[ "$expected_result_process" =~ ^\[.*\]$ ]]; then
         # Handle array of expected bridge results
-        echo "DEBUG: Processing array of expected bridge results: $expected_result_process" >&2
+        echo "[DEBUG]: Processing array of expected bridge results: $expected_result_process" >&2
         
         # Check if array contains "Success"
         if echo "$expected_result_process" | jq -r '.[]' | grep -q "^Success$"; then
             bridge_expects_success=true
-            echo "DEBUG: Bridge array contains 'Success' as valid outcome" >&2
+            echo "[DEBUG]: Bridge array contains 'Success' as valid outcome" >&2
         fi
         
         # Check if array contains other error patterns
         if echo "$expected_result_process" | jq -r '.[]' | grep -v "^Success$" | grep -q .; then
             bridge_has_other_expected_errors=true
-            echo "DEBUG: Bridge array contains other expected error patterns" >&2
+            echo "[DEBUG]: Bridge array contains other expected error patterns" >&2
         fi
     else
         # Single non-Success expected result
         bridge_has_other_expected_errors=true
     fi
     
-    echo "DEBUG: Bridge expects success: $bridge_expects_success, has other expected errors: $bridge_has_other_expected_errors" >&2
+    echo "[DEBUG]: Bridge expects success: $bridge_expects_success, has other expected errors: $bridge_has_other_expected_errors" >&2
     
     # Validate based on actual bridge result
     if [[ $bridge_status -eq 0 ]]; then
         # Bridge succeeded
         if $bridge_expects_success; then
             bridge_result="PASS"
-            echo "DEBUG: Bridge succeeded and success was expected" >&2
+            echo "[DEBUG]: Bridge succeeded and success was expected" >&2
             
             # Execute claim if expected (based on reference implementation)
             if [[ "$expected_result_claim" != "N/A" ]]; then
-                echo "DEBUG: Executing claim command for test $test_index" >&2
+                echo "[DEBUG]: Executing claim command for test $test_index" >&2
                 
                 # Build claim command based on reference
                 local claim_command="polycli ulxly claim"
@@ -1397,7 +1397,7 @@ _run_single_bridge_test() {
                     "Asset"|"Weth") claim_command="$claim_command asset" ;;
                     "Message") claim_command="$claim_command message" ;;
                     *) 
-                        echo "DEBUG: Unrecognized Bridge Type for claim: $test_bridge_type" >&2
+                        echo "[DEBUG]: Unrecognized Bridge Type for claim: $test_bridge_type" >&2
                         echo "TEST_$test_index|FAIL|N/A|Unrecognized Bridge Type for claim" > "$result_file"
                         return 1 
                         ;;
@@ -1407,22 +1407,22 @@ _run_single_bridge_test() {
                 claim_command="$claim_command --destination-address $dest_addr --bridge-address $claim_bridge_addr --private-key $ephemeral_private_key --rpc-url $claim_rpc_url --deposit-count $deposit_count --deposit-network $source_network_id --bridge-service-url $bridge_service_url --wait $claim_wait_duration"
                 
                 # Execute claim command
-                echo "DEBUG: Running claim command for test $test_index: $claim_command" >&2
+                echo "[DEBUG]: Running claim command for test $test_index: $claim_command" >&2
                 local claim_output claim_status
                 local max_claim_retries=3
                 local claim_attempt=0
 
                 while [[ $claim_attempt -lt $max_claim_retries ]]; do
                         claim_attempt=$((claim_attempt + 1))
-                        echo "DEBUG: Claim attempt $claim_attempt for test $test_index" >&2
+                        echo "[DEBUG]: Claim attempt $claim_attempt for test $test_index" >&2
 
                         if claim_output=$(timeout "$global_timeout" bash -c "$claim_command" 2>&1); then
                             claim_status=0
-                            echo "DEBUG: Claim command exited with status 0 on attempt $claim_attempt" >&2
+                            echo "[DEBUG]: Claim command exited with status 0 on attempt $claim_attempt" >&2
                             
                             # Even if exit status is 0, check for failure indicators in the output
                             if echo "$claim_output" | grep -q -E "(Deposit transaction failed|Perhaps try increasing the gas limit|GasUsed=[0-9]+ cumulativeGasUsedForTx=)"; then
-                                echo "DEBUG: Claim command succeeded but transaction failed - checking if already claimed" >&2
+                                echo "[DEBUG]: Claim command succeeded but transaction failed - checking if already claimed" >&2
                                 
                                 # Wait a moment for state to update, then check if it was actually claimed
                                 sleep 2
@@ -1433,7 +1433,7 @@ _run_single_bridge_test() {
                                 if verify_output=$(timeout 30 bash -c "$verify_command" 2>&1) || \
                                    verify_output=$(timeout 30 bash -c "$claim_command" 2>&1); then
                                     if echo "$verify_output" | grep -q -E "(already been claimed|AlreadyClaimedError|the claim transaction has already been claimed)"; then
-                                        echo "DEBUG: Verification shows deposit was already claimed by another process" >&2
+                                        echo "[DEBUG]: Verification shows deposit was already claimed by another process" >&2
                                         claim_status=0  # Treat as success
                                         claim_output="Deposit was already claimed (verified)"
                                         break
@@ -1444,28 +1444,28 @@ _run_single_bridge_test() {
                                 # it's likely already claimed by another process
                                 if echo "$claim_output" | grep -q "The deposit is ready to be claimed" && \
                                    echo "$claim_output" | grep -q "Deposit transaction failed"; then
-                                    echo "DEBUG: Deposit ready but transaction failed - likely already claimed by parallel process" >&2
+                                    echo "[DEBUG]: Deposit ready but transaction failed - likely already claimed by parallel process" >&2
                                     claim_status=0  # Treat as success
                                     claim_output="Deposit was likely already claimed by parallel process"
                                     break
                                 fi
                                 
                                 # If verification fails, treat the original failure as real
-                                echo "DEBUG: Transaction genuinely failed, not due to already claimed" >&2
+                                echo "[DEBUG]: Transaction genuinely failed, not due to already claimed" >&2
                                 claim_status=1
                                 break
                             else
-                                echo "DEBUG: Claim succeeded cleanly on attempt $claim_attempt" >&2
+                                echo "[DEBUG]: Claim succeeded cleanly on attempt $claim_attempt" >&2
                                 break
                             fi
                         else
                             claim_status=$?
-                            echo "DEBUG: Claim attempt $claim_attempt failed with exit status $claim_status" >&2
-                            echo "DEBUG: Claim output: $claim_output" >&2
+                            echo "[DEBUG]: Claim attempt $claim_attempt failed with exit status $claim_status" >&2
+                            echo "[DEBUG]: Claim output: $claim_output" >&2
 
                             # Check if it's already claimed - this should be treated as success
                             if echo "$claim_output" | grep -q -E "(already been claimed|AlreadyClaimedError|the claim transaction has already been claimed)"; then
-                                echo "DEBUG: Deposit already claimed - treating as success" >&2
+                                echo "[DEBUG]: Deposit already claimed - treating as success" >&2
                                 claim_status=0
                                 break
                             fi
@@ -1474,13 +1474,13 @@ _run_single_bridge_test() {
                             # This typically indicates the deposit was claimed between the ready check and the claim attempt
                             if echo "$claim_output" | grep -q "The deposit is ready to be claimed" && \
                                echo "$claim_output" | grep -q "Deposit transaction failed"; then
-                                echo "DEBUG: Deposit ready but transaction failed - likely race condition with parallel claim" >&2
+                                echo "[DEBUG]: Deposit ready but transaction failed - likely race condition with parallel claim" >&2
                                 
                                 # Do one final verification attempt
                                 local final_verify_output
                                 if final_verify_output=$(timeout 15 bash -c "$claim_command" 2>&1); then
                                     if echo "$final_verify_output" | grep -q -E "(already been claimed|AlreadyClaimedError|the claim transaction has already been claimed)"; then
-                                        echo "DEBUG: Final verification confirms deposit was already claimed" >&2
+                                        echo "[DEBUG]: Final verification confirms deposit was already claimed" >&2
                                         claim_status=0
                                         claim_output="Deposit was already claimed (race condition detected)"
                                         break
@@ -1489,7 +1489,7 @@ _run_single_bridge_test() {
                                     # If the verification also fails with the same pattern, assume it's already claimed
                                     if echo "$final_verify_output" | grep -q "The deposit is ready to be claimed" && \
                                        echo "$final_verify_output" | grep -q "Deposit transaction failed"; then
-                                        echo "DEBUG: Final verification shows same pattern - treating as already claimed" >&2
+                                        echo "[DEBUG]: Final verification shows same pattern - treating as already claimed" >&2
                                         claim_status=0
                                         claim_output="Deposit was already claimed (consistent failure pattern)"
                                         break
@@ -1499,7 +1499,7 @@ _run_single_bridge_test() {
 
                             # Check if it's a temporary "not ready" error - retry after delay
                             if echo "$claim_output" | grep -q -E "(not yet ready to be claimed|Try again in a few blocks)"; then
-                                echo "DEBUG: Claim not ready yet, will retry after delay" >&2
+                                echo "[DEBUG]: Claim not ready yet, will retry after delay" >&2
                                 if [[ $claim_attempt -lt $max_claim_retries ]]; then
                                     sleep 5  # Wait before retry
                                     continue
@@ -1508,19 +1508,19 @@ _run_single_bridge_test() {
 
                             # For other errors, don't retry immediately but check if it might be an already-claimed case
                             if echo "$claim_output" | grep -q -E "(Deposit transaction failed|Perhaps try increasing the gas limit)"; then
-                                echo "DEBUG: Got transaction failure error - checking if deposit was actually claimed" >&2
+                                echo "[DEBUG]: Got transaction failure error - checking if deposit was actually claimed" >&2
                                 sleep 2  # Brief pause for state propagation
                                 
                                 # Try one more time to see if the error message changes to "already claimed"
                                 local final_check_output
                                 if final_check_output=$(timeout 30 bash -c "$claim_command" 2>&1); then
-                                    echo "DEBUG: Final check succeeded unexpectedly" >&2
+                                    echo "[DEBUG]: Final check succeeded unexpectedly" >&2
                                     claim_status=0
                                     claim_output="$final_check_output"
                                     break
                                 else
                                     if echo "$final_check_output" | grep -q -E "(already been claimed|AlreadyClaimedError|the claim transaction has already been claimed)"; then
-                                        echo "DEBUG: Final check confirms deposit was already claimed" >&2
+                                        echo "[DEBUG]: Final check confirms deposit was already claimed" >&2
                                         claim_status=0
                                         claim_output="$final_check_output"
                                         break
@@ -1533,7 +1533,7 @@ _run_single_bridge_test() {
                         fi
                     done
                 
-                echo "DEBUG: Claim command output for test $test_index: $claim_output" >&2
+                echo "[DEBUG]: Claim command output for test $test_index: $claim_output" >&2
 
                 # Validate claim result with array support
                 local claim_expects_success=false
@@ -1544,37 +1544,37 @@ _run_single_bridge_test() {
                     claim_expects_success=true
                 elif [[ "$expected_result_claim" =~ ^\[.*\]$ ]]; then
                     # Handle array of expected claim results
-                    echo "DEBUG: Processing array of expected claim results: $expected_result_claim" >&2
+                    echo "[DEBUG]: Processing array of expected claim results: $expected_result_claim" >&2
                     
                     # Check if array contains "Success"
                     if echo "$expected_result_claim" | jq -r '.[]' | grep -q "^Success$"; then
                         claim_expects_success=true
-                        echo "DEBUG: Claim array contains 'Success' as valid outcome" >&2
+                        echo "[DEBUG]: Claim array contains 'Success' as valid outcome" >&2
                     fi
                     
                     # Check if array contains other error patterns
                     if echo "$expected_result_claim" | jq -r '.[]' | grep -v "^Success$" | grep -q .; then
                         claim_has_other_expected_errors=true
-                        echo "DEBUG: Claim array contains other expected error patterns" >&2
+                        echo "[DEBUG]: Claim array contains other expected error patterns" >&2
                     fi
                 else
                     # Single non-Success expected result
                     claim_has_other_expected_errors=true
                 fi
                 
-                echo "DEBUG: Claim expects success: $claim_expects_success, has other expected errors: $claim_has_other_expected_errors" >&2
+                echo "[DEBUG]: Claim expects success: $claim_expects_success, has other expected errors: $claim_has_other_expected_errors" >&2
                 
                 # Validate claim result
                 if [[ $claim_status -eq 0 ]]; then
                     # Claim succeeded
                     if $claim_expects_success; then
                         claim_result="PASS"
-                        echo "DEBUG: Claim succeeded and success was expected" >&2
+                        echo "[DEBUG]: Claim succeeded and success was expected" >&2
                     else
                         # Success not expected, but check if already claimed
                         if echo "$claim_output" | grep -q -E "(already been claimed|AlreadyClaimedError|the claim transaction has already been claimed)"; then
                             claim_result="PASS"
-                            echo "DEBUG: Claim succeeded but only because already claimed" >&2
+                            echo "[DEBUG]: Claim succeeded but only because already claimed" >&2
                         else
                             claim_result="FAIL"
                             error_message="Expected claim failure but succeeded for deposit $deposit_count"
@@ -1584,15 +1584,15 @@ _run_single_bridge_test() {
                     # Claim failed
                     if echo "$claim_output" | grep -q -E "(already been claimed|AlreadyClaimedError|the claim transaction has already been claimed)"; then
                         claim_result="PASS"
-                        echo "DEBUG: Deposit $deposit_count already claimed, treating as success" >&2
+                        echo "[DEBUG]: Deposit $deposit_count already claimed, treating as success" >&2
                     elif $claim_has_other_expected_errors && _validate_bridge_error "$expected_result_claim" "$claim_output"; then
                         claim_result="PASS"
-                        echo "DEBUG: Claim failed with expected error pattern" >&2
+                        echo "[DEBUG]: Claim failed with expected error pattern" >&2
                     elif $claim_expects_success && ! $claim_has_other_expected_errors; then
                         # Only expected success, but got failure - check if it's AlreadyClaimedError
                         if echo "$claim_output" | grep -q -E "(already been claimed|AlreadyClaimedError)"; then
                             claim_result="PASS"
-                            echo "DEBUG: Claim failed with AlreadyClaimedError but this counts as success" >&2
+                            echo "[DEBUG]: Claim failed with AlreadyClaimedError but this counts as success" >&2
                         else
                             claim_result="FAIL"
                             error_message="Expected claim success but failed for deposit $deposit_count"
@@ -1617,7 +1617,7 @@ _run_single_bridge_test() {
         # Bridge failed
         if $bridge_has_other_expected_errors && _validate_bridge_error "$expected_result_process" "$bridge_output"; then
             bridge_result="PASS"
-            echo "DEBUG: Bridge failed with expected error pattern" >&2
+            echo "[DEBUG]: Bridge failed with expected error pattern" >&2
         elif $bridge_expects_success && ! $bridge_has_other_expected_errors; then
             # Only expected success, but got failure
             bridge_result="FAIL"
@@ -1639,7 +1639,7 @@ _run_single_bridge_test() {
     # Write result to file
     echo "TEST_$test_index|$bridge_result|$claim_result|$error_message" > "$result_file"
     
-    echo "DEBUG: Completed bridge test $test_index" >&2
+    echo "[DEBUG]: Completed bridge test $test_index" >&2
 }
 
 

--- a/tests/lxly/bridge-tests-suite.bats
+++ b/tests/lxly/bridge-tests-suite.bats
@@ -570,3 +570,34 @@ _setup_contract_addresses() {
         done
     done
 }
+
+# bats test_tags=bridge
+@test "Reclaim test funds" {
+    # Sanity check for l1_rpc_url
+    if [[ -z "$l1_rpc_url" ]]; then
+        echo "Error: l1_rpc_url is empty" >&3
+        return 1
+    fi
+
+    # Sanity check for l2_rpc_url
+    if [[ -z "$l2_rpc_url" ]]; then
+        echo "Error: l2_rpc_url is empty" >&3
+        return 1
+    fi
+
+    # Check and reclaim funds for L1
+    if [[ ! "$l1_rpc_url" =~ 127.0.0.1 ]]; then
+        echo "Non-Kurtosis L1 network detected, attempting to reclaim funds..." >&3
+        _reclaim_funds_after_test "$l1_eth_address" "$l1_rpc_url"
+    else
+        echo "Kurtosis L1 network detected, skipping reclaiming funds..." >&3
+    fi
+
+    # Check and reclaim funds for L2
+    if [[ ! "$l2_rpc_url" =~ 127.0.0.1 ]]; then
+        echo "Non-Kurtosis L2 network detected, attempting to reclaim funds..." >&3
+        _reclaim_funds_after_test "$l2_eth_address" "$l2_rpc_url"
+    else
+        echo "Kurtosis L2 network detected, skipping reclaiming funds..." >&3
+    fi
+}

--- a/tests/lxly/bridge-tests-suite.bats
+++ b/tests/lxly/bridge-tests-suite.bats
@@ -6,6 +6,10 @@
 # =============================================================================
 
 setup() {
+    # Source the logger functions
+    # shellcheck disable=SC1091
+    source "$PWD/core/helpers/logger.bash"
+
     # Initialize test_index for this test run
     test_index=0
 
@@ -44,7 +48,7 @@ _setup_environment_variables() {
     l1_rpc_url="${L1_RPC_URL:-http://$(kurtosis port print "$kurtosis_enclave_name" el-1-geth-lighthouse rpc)}"
     l1_bridge_addr="${L1_BRIDGE_ADDR:-0xD779d520D2F8DdD71Eb131f509f2f8Fa355362ae}"
     if [[ $(cast code $l1_bridge_addr --rpc-url $l1_rpc_url) == "0x" ]]; then
-        echo "Replacing empty bridge contract address..." >&3
+        _log_file_descriptor "3" "Replacing empty bridge contract address..."
         l1_bridge_addr=$(_get_bridge_address)
     fi
 
@@ -53,7 +57,7 @@ _setup_environment_variables() {
     l2_rpc_url="${L2_RPC_URL:-$(kurtosis port print "$kurtosis_enclave_name" op-el-1-op-geth-op-node-001 rpc)}"
     l2_bridge_addr="${L2_BRIDGE_ADDR:-0xD779d520D2F8DdD71Eb131f509f2f8Fa355362ae}"
     if [[ $(cast code $l2_bridge_addr --rpc-url $l2_rpc_url) == "0x" ]]; then
-        echo "Replacing empty bridge contract address..." >&3
+        _log_file_descriptor "3" "Replacing empty bridge contract address..."
         l2_bridge_addr=$(_get_bridge_address)
     fi
 
@@ -90,7 +94,7 @@ _setup_contract_addresses() {
 # bats test_tags=bridge
 @test "Initial setup" {
     [[ -f "./tests/lxly/assets/bridge-tests-suite.json" ]] || {
-        echo "Bridge Tests Suite file not found" >&3
+        _log_file_descriptor "3" "Bridge Tests Suite file not found"
         skip "Bridge Tests Suite file not found"
     }
 
@@ -109,9 +113,9 @@ _setup_contract_addresses() {
 
 # bats test_tags=bridge
 @test "Process L1 to L2 bridge scenarios and claim deposits in parallel" {
-    echo "[DEBUG]: Starting L1 to L2 parallel bridge scenarios and claims test" >&3
+    _log_file_descriptor "3" "Starting L1 to L2 parallel bridge scenarios and claims test"
     [[ -f "./tests/lxly/assets/bridge-tests-suite.json" ]] || {
-        echo "[DEBUG]: Bridge Tests Suite file not found" >&3
+        _log_file_descriptor "3" "Bridge Tests Suite file not found"
         skip "Bridge Tests Suite file not found"
     }
 
@@ -121,86 +125,86 @@ _setup_contract_addresses() {
     local output_dir="$log_root_dir/bridge_test_results_l1_to_l2_${timestamp}"
     mkdir -p "$output_dir"
     
-    echo "[DEBUG]: Test results will be saved to: $output_dir" >&3
+    _log_file_descriptor "3" "Test results will be saved to: $output_dir"
 
     
     # Get total number of scenarios
     local total_scenarios
     total_scenarios=$(echo "$scenarios" | jq '. | length')
-    echo "[DEBUG]: Total scenarios to process: $total_scenarios" >&3
+    _log_file_descriptor "3" "Total scenarios to process: $total_scenarios"
     
     # Save detailed setup log
     local setup_log="$output_dir/setup_phase.log"
-    
-    echo "" | tee "$setup_log"
-    echo "========================================" | tee -a "$setup_log"
-    echo "      PHASE 1: SEQUENTIAL SETUP         " | tee -a "$setup_log"
-    echo "              L1 -> L2                  " | tee -a "$setup_log"
-    echo "========================================" | tee -a "$setup_log"
+
+    echo "" | tee "$setup_log" >&3
+    echo "========================================" | tee -a "$setup_log" >&3
+    echo "      PHASE 1: SEQUENTIAL SETUP         " | tee -a "$setup_log" >&3
+    echo "              L1 -> L2                  " | tee -a "$setup_log" >&3
+    echo "========================================" | tee -a "$setup_log" >&3
     
     # Phase 1: Sequential setup of all test accounts
     local index=0
     local setup_failures=0
     local successful_setups=()  # Array to track successfully set up test indices
-    
-    echo "[DEBUG]: Setting up $total_scenarios test accounts..." >&3
-    
+
+    _log_file_descriptor "3" "Setting up $total_scenarios test accounts..." | tee -a "$setup_log"
+
     while read -r scenario; do
         local progress_percent=$((index * 100 / total_scenarios))
-        echo "[$progress_percent%] Setting up test account $index/$total_scenarios" | tee -a "$setup_log" >&3
+        _log_file_descriptor "3" "[$progress_percent%] Setting up test account $index/$total_scenarios" | tee -a "$setup_log"
         
-        if ! _setup_single_test_account "$index" "$scenario" "L1_TO_L2" 2>>"$output_dir/setup_debug_${index}.log"; then
-            echo "❌ Failed to set up account for test $index" | tee -a "$setup_log" >&3
+        if ! _setup_single_test_account "$index" "$scenario" "L2_TO_L1" 2>>"$output_dir/setup_debug_${index}.log"; then
+            _log_file_descriptor "3" "❌ Failed to set up account for test $index" | tee -a "$setup_log"
             setup_failures=$((setup_failures + 1))
         else
-            echo "✅ Successfully set up account for test $index" | tee -a "$setup_log"
+            _log_file_descriptor "3" "✅ Successfully set up account for test $index" | tee -a "$setup_log"
             successful_setups+=("$index")  # Track successful setup
         fi
         
         index=$((index + 1))
     done < <(echo "$scenarios" | jq -c '.[]')
-    
+
     local successful_count=${#successful_setups[@]}
-    
-    echo "" >&3
-    echo "Setup Phase Complete:" >&3
-    echo "  ✅ Successful setups: $successful_count" >&3
-    echo "  ❌ Failed setups: $setup_failures" >&3
-    
+
+    _log_file_descriptor "3" "" | tee -a "$setup_log"
+    _log_file_descriptor "3" "Setup Phase Complete:" | tee -a "$setup_log"
+    _log_file_descriptor "3" "  ✅ Successful setups: $successful_count" | tee -a "$setup_log"
+    _log_file_descriptor "3" "  ❌ Failed setups: $setup_failures" | tee -a "$setup_log"
+
     if [[ $setup_failures -gt 0 ]]; then
-        echo "Failed to set up $setup_failures out of $total_scenarios test accounts" | tee -a "$setup_log"
-        echo "Successfully set up $successful_count accounts" | tee -a "$setup_log"
-        echo "Setup logs saved to: $output_dir/setup_*.log" | tee -a "$setup_log"
+        echo "Failed to set up $setup_failures out of $total_scenarios test accounts" | tee -a "$setup_log" >&3
+        echo "Successfully set up $successful_count accounts" | tee -a "$setup_log" >&3
+        echo "Setup logs saved to: $output_dir/setup_*.log" | tee -a "$setup_log" >&3
         
         # Continue with successful setups if we have any
         if [[ $successful_count -eq 0 ]]; then
-            echo "No accounts were successfully set up, aborting test" | tee -a "$setup_log"
+            echo "No accounts were successfully set up, aborting test" | tee -a "$setup_log" >&3
             return 1
         fi
     else
-        echo "All $total_scenarios test accounts set up successfully" | tee -a "$setup_log"
+        echo "All $total_scenarios test accounts set up successfully" | tee -a "$setup_log" >&3
     fi
-    
+
     # Save detailed bridge test log
     local bridge_log="$output_dir/bridge_phase.log"
-    
-    echo "" | tee "$bridge_log"
-    echo "========================================" | tee -a "$bridge_log"
-    echo "      PHASE 2: PARALLEL BRIDGE TESTS    " | tee -a "$bridge_log"
-    echo "              L1 -> L2                  " | tee -a "$setup_log"
-    echo "========================================" | tee -a "$bridge_log"
-    
+
+    echo "" | tee "$bridge_log" >&3
+    echo "========================================" | tee -a "$bridge_log" >&3
+    echo "      PHASE 2: PARALLEL BRIDGE TESTS    " | tee -a "$bridge_log" >&3
+    echo "              L2 -> L1                  " | tee -a "$bridge_log" >&3
+    echo "========================================" | tee -a "$bridge_log" >&3
+
     # Phase 2: Run bridge tests in parallel - only for successfully set up accounts
     local max_concurrent=5
     if [[ $successful_count -lt 5 ]]; then
         max_concurrent=$successful_count
     fi
-    
-    echo "Running bridge tests for $successful_count successfully set up accounts" | tee -a "$bridge_log"
-    echo "Using max concurrency: $max_concurrent" | tee -a "$bridge_log"
-    
-    echo "" >&3
-    echo "Starting parallel bridge tests with max concurrency: $max_concurrent" >&3
+
+    echo "Running bridge tests for $successful_count successfully set up accounts" | tee -a "$bridge_log" >&3
+    echo "Using max concurrency: $max_concurrent" | tee -a "$bridge_log" >&3
+
+    _log_file_descriptor "3" ""
+    _log_file_descriptor "3" "Starting parallel bridge tests with max concurrency: $max_concurrent" | tee -a "$bridge_log"
     
     local pids=()
     local scenario_array
@@ -226,7 +230,7 @@ _setup_contract_addresses() {
             if [[ $new_completions -gt 0 ]]; then
                 completed_tests=$((completed_tests + new_completions))
                 local progress_percent=$((completed_tests * 100 / successful_count))
-                echo "[${progress_percent}%] Completed: $completed_tests/$successful_count bridge tests" >&3
+                _log_file_descriptor "3" "[${progress_percent}%] Completed: $completed_tests/$successful_count bridge tests"
             fi
             
             # Rebuild pids array to remove gaps
@@ -240,7 +244,7 @@ _setup_contract_addresses() {
         
         started_tests=$((started_tests + 1))
         local start_progress_percent=$((started_tests * 100 / successful_count))
-        echo "[${start_progress_percent}%] Starting bridge test $test_index (${started_tests}/${successful_count})" | tee -a "$bridge_log" >&3
+        _log_file_descriptor "3" "[${start_progress_percent}%] Starting bridge test $test_index (${started_tests}/${successful_count})" | tee -a "$bridge_log"
         
         _run_single_bridge_test "$test_index" "${scenario_array[$test_index]}" "L1_TO_L2" 2>"$output_dir/bridge_test_${test_index}.log" &
         local test_pid=$!
@@ -251,14 +255,14 @@ _setup_contract_addresses() {
         
     done
     
-    echo "Started all ${#successful_setups[@]} parallel bridge test processes" | tee -a "$bridge_log" >&3
+    _log_file_descriptor "3" "Started all ${#successful_setups[@]} parallel bridge test processes" | tee -a "$bridge_log"
     
     # Wait for all remaining background processes to complete
     local wait_start
     wait_start=$(date +%s)
     
-    echo "" >&3
-    echo "Waiting for all bridge tests to complete..." >&3
+    _log_file_descriptor "3" ""
+    _log_file_descriptor "3" "Waiting for all bridge tests to complete..."
     
     while (( ${#pids[@]} > 0 )); do
         local current_time
@@ -268,7 +272,7 @@ _setup_contract_addresses() {
         local elapsed_seconds=$((elapsed % 60))
         
         if (( elapsed > ${global_timeout%s} )); then
-            echo "Timeout reached after ${elapsed_minutes}m${elapsed_seconds}s, killing remaining processes..." | tee -a "$bridge_log" >&3
+            _log_file_descriptor "3" "Timeout reached after ${elapsed_minutes}m${elapsed_seconds}s, killing remaining processes..." | tee -a "$bridge_log"
             for pid in "${pids[@]}"; do
                 kill -9 "$pid" 2>/dev/null || true
             done
@@ -290,7 +294,7 @@ _setup_contract_addresses() {
             completed_tests=$((completed_tests + new_completions))
             local progress_percent=$((completed_tests * 100 / successful_count))
             local remaining_tests=$((successful_count - completed_tests))
-            echo "[${progress_percent}%] Completed: $completed_tests/$successful_count tests (${remaining_tests} remaining) - ${elapsed_minutes}m${elapsed_seconds}s elapsed" >&3
+            _log_file_descriptor "3" "[${progress_percent}%] Completed: $completed_tests/$successful_count tests (${remaining_tests} remaining) - ${elapsed_minutes}m${elapsed_seconds}s elapsed"
         fi
         
         # Rebuild pids array to remove gaps
@@ -299,15 +303,15 @@ _setup_contract_addresses() {
         # Show periodic progress even if no completions
         if (( elapsed % 30 == 0 )); then
             local active_processes=${#pids[@]}
-            echo "Status: $active_processes tests still running, $completed_tests/$successful_count completed - ${elapsed_minutes}m${elapsed_seconds}s elapsed" >&3
+            _log_file_descriptor "3" "Status: $active_processes tests still running, $completed_tests/$successful_count completed - ${elapsed_minutes}m${elapsed_seconds}s elapsed"
         fi
         
         # Wait a bit before checking again
         sleep 1
     done
     
-    echo "" >&3
-    echo "[DEBUG]: All bridge tests completed! Collecting results..." >&3
+    _log_file_descriptor "3" ""
+    _log_file_descriptor "3" "All bridge tests completed! Collecting results..."
     
     # Collect and report results - pass the successful count instead of total
     _collect_and_report_results "$output_dir" "$bridge_log" "$successful_count"
@@ -315,12 +319,12 @@ _setup_contract_addresses() {
     
     # Report setup failures in the final summary but don't fail the test for them
     if [[ $setup_failures -gt 0 ]]; then
-        echo "[DEBUG]: Note: $setup_failures accounts failed setup and were skipped" >&3
+        _log_file_descriptor "3" "Note: $setup_failures accounts failed setup and were skipped"
     fi
     
     # Fail the test only if bridge tests failed (not setup failures)
     [[ $failed_tests -eq 0 ]] || {
-        echo "[DEBUG]: Some bridge tests failed. Check the detailed logs in $output_dir" >&3
+        _log_file_descriptor "3" "Some bridge tests failed. Check the detailed logs in $output_dir"
         return 1
     }
 }
@@ -328,7 +332,7 @@ _setup_contract_addresses() {
 
 # bats test_tags=bridge
 @test "Process L2 to L1 bridge scenarios and claim deposits in parallel" {
-    echo "[DEBUG]: Starting L2 to L1 parallel bridge scenarios and claims test" >&3
+    _log_file_descriptor "3" "Starting L2 to L1 parallel bridge scenarios and claims test"
     [[ -f "./tests/lxly/assets/bridge-tests-suite.json" ]] || {
         echo "Bridge Tests Suite file not found" >&3
         skip "Bridge Tests Suite file not found"
@@ -340,30 +344,30 @@ _setup_contract_addresses() {
     local output_dir="$log_root_dir/bridge_test_results_l2_to_l1_${timestamp}"
     mkdir -p "$output_dir"
     
-    echo "[DEBUG]: Test results will be saved to: $output_dir" >&3
+    _log_file_descriptor "3" "Test results will be saved to: $output_dir"
 
     
     # Get total number of scenarios
     local total_scenarios
     total_scenarios=$(echo "$scenarios" | jq '. | length')
-    echo "[DEBUG]: Total scenarios to process: $total_scenarios" >&3
+    _log_file_descriptor "3" "Total scenarios to process: $total_scenarios"
     
     # Save detailed setup log
     local setup_log="$output_dir/setup_phase.log"
     
-    echo "" | tee "$setup_log"
-    echo "========================================" | tee -a "$setup_log"
-    echo "      PHASE 1: SEQUENTIAL SETUP         " | tee -a "$setup_log"
-    echo "              L2 -> L1                  " | tee -a "$setup_log"
-    echo "========================================" | tee -a "$setup_log"
+    echo "" | tee "$setup_log" >&3
+    echo "========================================" | tee -a "$setup_log" >&3
+    echo "      PHASE 1: SEQUENTIAL SETUP         " | tee -a "$setup_log" >&3
+    echo "              L2 -> L1                  " | tee -a "$setup_log" >&3
+    echo "========================================" | tee -a "$setup_log" >&3
     
     # Phase 1: Sequential setup of all test accounts
     local index=0
     local setup_failures=0
     local successful_setups=()  # Array to track successfully set up test indices
-    
-    echo "[DEBUG]: Setting up $total_scenarios test accounts..." >&3
-    
+
+    echo "Setting up $total_scenarios test accounts..." | tee -a "$setup_log" >&3
+
     while read -r scenario; do
         local progress_percent=$((index * 100 / total_scenarios))
         echo "[$progress_percent%] Setting up test account $index/$total_scenarios" | tee -a "$setup_log" >&3
@@ -372,54 +376,54 @@ _setup_contract_addresses() {
             echo "❌ Failed to set up account for test $index" | tee -a "$setup_log" >&3
             setup_failures=$((setup_failures + 1))
         else
-            echo "✅ Successfully set up account for test $index" | tee -a "$setup_log"
+            echo "✅ Successfully set up account for test $index" | tee -a "$setup_log" >&3
             successful_setups+=("$index")  # Track successful setup
         fi
         
         index=$((index + 1))
     done < <(echo "$scenarios" | jq -c '.[]')
-    
+
     local successful_count=${#successful_setups[@]}
-    
-    echo "" >&3
-    echo "Setup Phase Complete:" >&3
-    echo "  ✅ Successful setups: $successful_count" >&3
-    echo "  ❌ Failed setups: $setup_failures" >&3
-    
+
+    echo "" | tee -a "$setup_log" >&3
+    echo "Setup Phase Complete:" | tee -a "$setup_log" >&3
+    echo "  ✅ Successful setups: $successful_count" | tee -a "$setup_log" >&3
+    echo "  ❌ Failed setups: $setup_failures" | tee -a "$setup_log" >&3
+
     if [[ $setup_failures -gt 0 ]]; then
-        echo "Failed to set up $setup_failures out of $total_scenarios test accounts" | tee -a "$setup_log"
-        echo "Successfully set up $successful_count accounts" | tee -a "$setup_log"
-        echo "Setup logs saved to: $output_dir/setup_*.log" | tee -a "$setup_log"
+        echo "Failed to set up $setup_failures out of $total_scenarios test accounts" | tee -a "$setup_log" >&3
+        echo "Successfully set up $successful_count accounts" | tee -a "$setup_log" >&3
+        echo "Setup logs saved to: $output_dir/setup_*.log" | tee -a "$setup_log" >&3
         
         # Continue with successful setups if we have any
         if [[ $successful_count -eq 0 ]]; then
-            echo "No accounts were successfully set up, aborting test" | tee -a "$setup_log"
+            echo "No accounts were successfully set up, aborting test" | tee -a "$setup_log" >&3
             return 1
         fi
     else
-        echo "All $total_scenarios test accounts set up successfully" | tee -a "$setup_log"
+        echo "All $total_scenarios test accounts set up successfully" | tee -a "$setup_log" >&3
     fi
-    
+
     # Save detailed bridge test log
     local bridge_log="$output_dir/bridge_phase.log"
-    
-    echo "" | tee "$bridge_log"
-    echo "========================================" | tee -a "$bridge_log"
-    echo "      PHASE 2: PARALLEL BRIDGE TESTS    " | tee -a "$bridge_log"
-    echo "              L2 -> L1                  " | tee -a "$setup_log"
-    echo "========================================" | tee -a "$bridge_log"
-    
+
+    echo "" | tee "$bridge_log" >&3
+    echo "========================================" | tee -a "$bridge_log" >&3
+    echo "      PHASE 2: PARALLEL BRIDGE TESTS    " | tee -a "$bridge_log" >&3
+    echo "              L2 -> L1                  " | tee -a "$bridge_log" >&3
+    echo "========================================" | tee -a "$bridge_log" >&3
+
     # Phase 2: Run bridge tests in parallel - only for successfully set up accounts
     local max_concurrent=5
     if [[ $successful_count -lt 5 ]]; then
         max_concurrent=$successful_count
     fi
-    
-    echo "Running bridge tests for $successful_count successfully set up accounts" | tee -a "$bridge_log"
-    echo "Using max concurrency: $max_concurrent" | tee -a "$bridge_log"
-    
-    echo "" >&3
-    echo "Starting parallel bridge tests with max concurrency: $max_concurrent" >&3
+
+    echo "Running bridge tests for $successful_count successfully set up accounts" | tee -a "$bridge_log" >&3
+    echo "Using max concurrency: $max_concurrent" | tee -a "$bridge_log" >&3
+
+    echo "" | tee -a "$bridge_log" >&3
+    echo "Starting parallel bridge tests with max concurrency: $max_concurrent" | tee -a "$bridge_log" >&3
     
     local pids=()
     local scenario_array
@@ -445,7 +449,7 @@ _setup_contract_addresses() {
             if [[ $new_completions -gt 0 ]]; then
                 completed_tests=$((completed_tests + new_completions))
                 local progress_percent=$((completed_tests * 100 / successful_count))
-                echo "[${progress_percent}%] Completed: $completed_tests/$successful_count bridge tests" >&3
+                _log_file_descriptor "3" "[${progress_percent}%] Completed: $completed_tests/$successful_count bridge tests"
             fi
             
             # Rebuild pids array to remove gaps
@@ -460,24 +464,24 @@ _setup_contract_addresses() {
         started_tests=$((started_tests + 1))
         local start_progress_percent=$((started_tests * 100 / successful_count))
         echo "[${start_progress_percent}%] Starting bridge test $test_index (${started_tests}/${successful_count})" | tee -a "$bridge_log" >&3
-        
+
         _run_single_bridge_test "$test_index" "${scenario_array[$test_index]}" "L2_TO_L1" 2>"$output_dir/bridge_test_${test_index}.log" &
         local test_pid=$!
         pids+=("$test_pid")
-        
+
         # Small delay to stagger test starts
         sleep 0.1
         
     done
     
     echo "Started all ${#successful_setups[@]} parallel bridge test processes" | tee -a "$bridge_log" >&3
-    
+
     # Wait for all remaining background processes to complete
     local wait_start
     wait_start=$(date +%s)
-    
-    echo "" >&3
-    echo "Waiting for all bridge tests to complete..." >&3
+
+    echo "" | tee -a "$bridge_log" >&3
+    echo "Waiting for all bridge tests to complete..." | tee -a "$bridge_log" >&3
     
     while (( ${#pids[@]} > 0 )); do
         local current_time
@@ -487,7 +491,7 @@ _setup_contract_addresses() {
         local elapsed_seconds=$((elapsed % 60))
         
         if (( elapsed > ${global_timeout%s} )); then
-            echo "Timeout reached after ${elapsed_minutes}m${elapsed_seconds}s, killing remaining processes..." | tee -a "$bridge_log" >&3
+            _log_file_descriptor "3" "Timeout reached after ${elapsed_minutes}m${elapsed_seconds}s, killing remaining processes..." | tee -a "$bridge_log"
             for pid in "${pids[@]}"; do
                 kill -9 "$pid" 2>/dev/null || true
             done
@@ -498,7 +502,7 @@ _setup_contract_addresses() {
         local new_completions=0
         for i in "${!pids[@]}"; do
             if ! kill -0 "${pids[$i]}" 2>/dev/null; then
-                echo "Bridge test process ${pids[$i]} completed" | tee -a "$bridge_log"
+                _log_file_descriptor "3" "Bridge test process ${pids[$i]} completed" | tee -a "$bridge_log"
                 unset 'pids[$i]'
                 new_completions=$((new_completions + 1))
             fi
@@ -509,7 +513,7 @@ _setup_contract_addresses() {
             completed_tests=$((completed_tests + new_completions))
             local progress_percent=$((completed_tests * 100 / successful_count))
             local remaining_tests=$((successful_count - completed_tests))
-            echo "[${progress_percent}%] Completed: $completed_tests/$successful_count tests (${remaining_tests} remaining) - ${elapsed_minutes}m${elapsed_seconds}s elapsed" >&3
+            _log_file_descriptor "3" "[${progress_percent}%] Completed: $completed_tests/$successful_count tests (${remaining_tests} remaining) - ${elapsed_minutes}m${elapsed_seconds}s elapsed"
         fi
         
         # Rebuild pids array to remove gaps
@@ -518,15 +522,15 @@ _setup_contract_addresses() {
         # Show periodic progress even if no completions
         if (( elapsed % 30 == 0 )); then
             local active_processes=${#pids[@]}
-            echo "Status: $active_processes tests still running, $completed_tests/$successful_count completed - ${elapsed_minutes}m${elapsed_seconds}s elapsed" >&3
+            _log_file_descriptor "3" "Status: $active_processes tests still running, $completed_tests/$successful_count completed - ${elapsed_minutes}m${elapsed_seconds}s elapsed"
         fi
         
         # Wait a bit before checking again
         sleep 1
     done
     
-    echo "" >&3
-    echo "[DEBUG]: All bridge tests completed! Collecting results..." >&3
+    _log_file_descriptor "3" ""
+    _log_file_descriptor "3" "All bridge tests completed! Collecting results..."
     
     # Collect and report results - pass the successful count instead of total
     _collect_and_report_results "$output_dir" "$bridge_log" "$successful_count"
@@ -534,12 +538,12 @@ _setup_contract_addresses() {
     
     # Report setup failures in the final summary but don't fail the test for them
     if [[ $setup_failures -gt 0 ]]; then
-        echo "Note: $setup_failures accounts failed setup and were skipped" >&3
+        _log_file_descriptor "3" "Note: $setup_failures accounts failed setup and were skipped"
     fi
     
     # Fail the test only if bridge tests failed (not setup failures)
     [[ $failed_tests -eq 0 ]] || {
-        echo "Some bridge tests failed. Check the detailed logs in $output_dir" >&3
+        _log_file_descriptor "3" "Some bridge tests failed. Check the detailed logs in $output_dir"
         return 1
     }
 }
@@ -579,29 +583,29 @@ _setup_contract_addresses() {
 @test "Reclaim test funds" {
     # Sanity check for l1_rpc_url
     if [[ -z "$l1_rpc_url" ]]; then
-        echo "[ERROR]: l1_rpc_url is empty" >&3
+        _log_file_descriptor "3" "l1_rpc_url is empty"
         return 1
     fi
 
     # Sanity check for l2_rpc_url
     if [[ -z "$l2_rpc_url" ]]; then
-        echo "[Error]: l2_rpc_url is empty" >&3
+        _log_file_descriptor "3" "l2_rpc_url is empty"
         return 1
     fi
 
     # Check and reclaim funds for L1
     if [[ ! "$l1_rpc_url" =~ 127.0.0.1 ]]; then
-        echo "[DEBUG]: Non-Kurtosis L1 network detected, attempting to reclaim funds..." >&3
+        _log_file_descriptor "3" "Non-Kurtosis L1 network detected, attempting to reclaim funds..."
         _reclaim_funds_after_test "$l1_eth_address" "$l1_rpc_url"
     else
-        echo "[DEBUG]: Kurtosis L1 network detected, skipping reclaiming funds..." >&3
+        _log_file_descriptor "3" "Kurtosis L1 network detected, skipping reclaiming funds..."
     fi
 
     # Check and reclaim funds for L2
     if [[ ! "$l2_rpc_url" =~ 127.0.0.1 ]]; then
-        echo "[DEBUG]: Non-Kurtosis L2 network detected, attempting to reclaim funds..." >&3
+        _log_file_descriptor "3" "Non-Kurtosis L2 network detected, attempting to reclaim funds..."
         _reclaim_funds_after_test "$l2_eth_address" "$l2_rpc_url"
     else
-        echo "[DEBUG]: Kurtosis L2 network detected, skipping reclaiming funds..." >&3
+        _log_file_descriptor "3" "Kurtosis L2 network detected, skipping reclaiming funds..."
     fi
 }

--- a/tests/lxly/bridge-tests-suite.bats
+++ b/tests/lxly/bridge-tests-suite.bats
@@ -109,9 +109,9 @@ _setup_contract_addresses() {
 
 # bats test_tags=bridge
 @test "Process L1 to L2 bridge scenarios and claim deposits in parallel" {
-    echo "Starting L1 to L2 parallel bridge scenarios and claims test" >&3
+    echo "[DEBUG]: Starting L1 to L2 parallel bridge scenarios and claims test" >&3
     [[ -f "./tests/lxly/assets/bridge-tests-suite.json" ]] || {
-        echo "Bridge Tests Suite file not found" >&3
+        echo "[DEBUG]: Bridge Tests Suite file not found" >&3
         skip "Bridge Tests Suite file not found"
     }
 
@@ -121,20 +121,21 @@ _setup_contract_addresses() {
     local output_dir="$log_root_dir/bridge_test_results_l1_to_l2_${timestamp}"
     mkdir -p "$output_dir"
     
-    echo "Test results will be saved to: $output_dir" >&3
+    echo "[DEBUG]: Test results will be saved to: $output_dir" >&3
 
     
     # Get total number of scenarios
     local total_scenarios
     total_scenarios=$(echo "$scenarios" | jq '. | length')
-    echo "Total scenarios to process: $total_scenarios" >&3
+    echo "[DEBUG]: Total scenarios to process: $total_scenarios" >&3
     
     # Save detailed setup log
     local setup_log="$output_dir/setup_phase.log"
     
     echo "" | tee "$setup_log"
     echo "========================================" | tee -a "$setup_log"
-    echo "      PHASE 1: SEQUENTIAL SETUP        " | tee -a "$setup_log"
+    echo "      PHASE 1: SEQUENTIAL SETUP         " | tee -a "$setup_log"
+    echo "              L1 -> L2                  " | tee -a "$setup_log"
     echo "========================================" | tee -a "$setup_log"
     
     # Phase 1: Sequential setup of all test accounts
@@ -142,7 +143,7 @@ _setup_contract_addresses() {
     local setup_failures=0
     local successful_setups=()  # Array to track successfully set up test indices
     
-    echo "Setting up $total_scenarios test accounts..." >&3
+    echo "[DEBUG]: Setting up $total_scenarios test accounts..." >&3
     
     while read -r scenario; do
         local progress_percent=$((index * 100 / total_scenarios))
@@ -185,7 +186,8 @@ _setup_contract_addresses() {
     
     echo "" | tee "$bridge_log"
     echo "========================================" | tee -a "$bridge_log"
-    echo "      PHASE 2: PARALLEL BRIDGE TESTS   " | tee -a "$bridge_log"
+    echo "      PHASE 2: PARALLEL BRIDGE TESTS    " | tee -a "$bridge_log"
+    echo "              L1 -> L2                  " | tee -a "$setup_log"
     echo "========================================" | tee -a "$bridge_log"
     
     # Phase 2: Run bridge tests in parallel - only for successfully set up accounts
@@ -305,7 +307,7 @@ _setup_contract_addresses() {
     done
     
     echo "" >&3
-    echo "All bridge tests completed! Collecting results..." >&3
+    echo "[DEBUG]: All bridge tests completed! Collecting results..." >&3
     
     # Collect and report results - pass the successful count instead of total
     _collect_and_report_results "$output_dir" "$bridge_log" "$successful_count"
@@ -313,12 +315,12 @@ _setup_contract_addresses() {
     
     # Report setup failures in the final summary but don't fail the test for them
     if [[ $setup_failures -gt 0 ]]; then
-        echo "Note: $setup_failures accounts failed setup and were skipped" >&3
+        echo "[DEBUG]: Note: $setup_failures accounts failed setup and were skipped" >&3
     fi
     
     # Fail the test only if bridge tests failed (not setup failures)
     [[ $failed_tests -eq 0 ]] || {
-        echo "Some bridge tests failed. Check the detailed logs in $output_dir" >&3
+        echo "[DEBUG]: Some bridge tests failed. Check the detailed logs in $output_dir" >&3
         return 1
     }
 }
@@ -326,7 +328,7 @@ _setup_contract_addresses() {
 
 # bats test_tags=bridge
 @test "Process L2 to L1 bridge scenarios and claim deposits in parallel" {
-    echo "Starting L2 to L1 parallel bridge scenarios and claims test" >&3
+    echo "[DEBUG]: Starting L2 to L1 parallel bridge scenarios and claims test" >&3
     [[ -f "./tests/lxly/assets/bridge-tests-suite.json" ]] || {
         echo "Bridge Tests Suite file not found" >&3
         skip "Bridge Tests Suite file not found"
@@ -338,20 +340,21 @@ _setup_contract_addresses() {
     local output_dir="$log_root_dir/bridge_test_results_l2_to_l1_${timestamp}"
     mkdir -p "$output_dir"
     
-    echo "Test results will be saved to: $output_dir" >&3
+    echo "[DEBUG]: Test results will be saved to: $output_dir" >&3
 
     
     # Get total number of scenarios
     local total_scenarios
     total_scenarios=$(echo "$scenarios" | jq '. | length')
-    echo "Total scenarios to process: $total_scenarios" >&3
+    echo "[DEBUG]: Total scenarios to process: $total_scenarios" >&3
     
     # Save detailed setup log
     local setup_log="$output_dir/setup_phase.log"
     
     echo "" | tee "$setup_log"
     echo "========================================" | tee -a "$setup_log"
-    echo "      PHASE 1: SEQUENTIAL SETUP        " | tee -a "$setup_log"
+    echo "      PHASE 1: SEQUENTIAL SETUP         " | tee -a "$setup_log"
+    echo "              L2 -> L1                  " | tee -a "$setup_log"
     echo "========================================" | tee -a "$setup_log"
     
     # Phase 1: Sequential setup of all test accounts
@@ -359,7 +362,7 @@ _setup_contract_addresses() {
     local setup_failures=0
     local successful_setups=()  # Array to track successfully set up test indices
     
-    echo "Setting up $total_scenarios test accounts..." >&3
+    echo "[DEBUG]: Setting up $total_scenarios test accounts..." >&3
     
     while read -r scenario; do
         local progress_percent=$((index * 100 / total_scenarios))
@@ -402,7 +405,8 @@ _setup_contract_addresses() {
     
     echo "" | tee "$bridge_log"
     echo "========================================" | tee -a "$bridge_log"
-    echo "      PHASE 2: PARALLEL BRIDGE TESTS   " | tee -a "$bridge_log"
+    echo "      PHASE 2: PARALLEL BRIDGE TESTS    " | tee -a "$bridge_log"
+    echo "              L2 -> L1                  " | tee -a "$setup_log"
     echo "========================================" | tee -a "$bridge_log"
     
     # Phase 2: Run bridge tests in parallel - only for successfully set up accounts
@@ -522,7 +526,7 @@ _setup_contract_addresses() {
     done
     
     echo "" >&3
-    echo "All bridge tests completed! Collecting results..." >&3
+    echo "[DEBUG]: All bridge tests completed! Collecting results..." >&3
     
     # Collect and report results - pass the successful count instead of total
     _collect_and_report_results "$output_dir" "$bridge_log" "$successful_count"
@@ -575,29 +579,29 @@ _setup_contract_addresses() {
 @test "Reclaim test funds" {
     # Sanity check for l1_rpc_url
     if [[ -z "$l1_rpc_url" ]]; then
-        echo "Error: l1_rpc_url is empty" >&3
+        echo "[ERROR]: l1_rpc_url is empty" >&3
         return 1
     fi
 
     # Sanity check for l2_rpc_url
     if [[ -z "$l2_rpc_url" ]]; then
-        echo "Error: l2_rpc_url is empty" >&3
+        echo "[Error]: l2_rpc_url is empty" >&3
         return 1
     fi
 
     # Check and reclaim funds for L1
     if [[ ! "$l1_rpc_url" =~ 127.0.0.1 ]]; then
-        echo "Non-Kurtosis L1 network detected, attempting to reclaim funds..." >&3
+        echo "[DEBUG]: Non-Kurtosis L1 network detected, attempting to reclaim funds..." >&3
         _reclaim_funds_after_test "$l1_eth_address" "$l1_rpc_url"
     else
-        echo "Kurtosis L1 network detected, skipping reclaiming funds..." >&3
+        echo "[DEBUG]: Kurtosis L1 network detected, skipping reclaiming funds..." >&3
     fi
 
     # Check and reclaim funds for L2
     if [[ ! "$l2_rpc_url" =~ 127.0.0.1 ]]; then
-        echo "Non-Kurtosis L2 network detected, attempting to reclaim funds..." >&3
+        echo "[DEBUG]: Non-Kurtosis L2 network detected, attempting to reclaim funds..." >&3
         _reclaim_funds_after_test "$l2_eth_address" "$l2_rpc_url"
     else
-        echo "Kurtosis L2 network detected, skipping reclaiming funds..." >&3
+        echo "[DEBUG]: Kurtosis L2 network detected, skipping reclaiming funds..." >&3
     fi
 }


### PR DESCRIPTION
- Add reclaim funds logic after RPC bridge tests
- Clean up logging style
- Increase time between triggering nightly jobs
    - Although the nightly jobs are supposed to use different runners, if both are running together, the tests seem much slower