### PR TITLE
chore: fix test detection to handle indented annotations

### DIFF
--- a/scripts/update-tests-inventory.sh
+++ b/scripts/update-tests-inventory.sh
@@ -34,13 +34,13 @@ extract_test_info() {
     local relative_path="${file#${PROJECT_ROOT}/}"
     
     # Extract test names from @test lines
-    grep -n "^@test" "$file" | while IFS=: read -r line_num content; do
+    while IFS=: read -r line_num content; do
         # Extract test name from @test "test name"
         test_name=$(echo "$content" | sed -n 's/@test "\([^"]*\)".*/\1/p')
         if [[ -n "$test_name" ]]; then
             echo "| $test_name | [Link](./$relative_path#L$line_num) | |"
         fi
-    done
+    done < <(grep -n "^[[:space:]]*@test" "$file")
 }
 
 # Function to categorize tests based on file path


### PR DESCRIPTION
noticed that tests with leading spaces weren’t being picked up correctly.
replaced the original `grep -n "^@test"` with a `while ... done < <(grep -n "^[[:space:]]*@test")` approach so that annotations with any amount of indentation are now detected reliably.