### PR TITLE
feat: extract global index from bridge info by default

### DIFF
--- a/core/helpers/scripts/aggkit_bridge_service.bash
+++ b/core/helpers/scripts/aggkit_bridge_service.bash
@@ -143,12 +143,9 @@ function claim_bridge() {
         log "🔍 Attempt ${attempt}/${max_attempts}"
 
         local global_index
-        if [[ "$manipulated_unused_bits" == "true" || "$manipulated_rollup_id" == "true" ]]; then
-            global_index=$(generate_global_index "$bridge_info" "$source_network_id" "$manipulated_unused_bits" "$manipulated_rollup_id")
-        else
-            global_index="$(echo "$bridge_info" | jq -r '.global_index')"
-        fi
-        log "🔍 Global index: $global_index"
+        global_index=$(generate_global_index "$bridge_info" "$source_network_id" "$manipulated_unused_bits" "$manipulated_rollup_id")
+        log "🔍 Bridge Info Global index: $(echo "$bridge_info" | jq -r '.global_index')"
+        log "🔍 Calculated Global index: $global_index"
 
         run claim_call "$bridge_info" "$proof" "$destination_rpc_url" "$bridge_addr" "$global_index"
         local request_result="$status"

--- a/core/helpers/scripts/aggkit_bridge_service.bash
+++ b/core/helpers/scripts/aggkit_bridge_service.bash
@@ -143,7 +143,11 @@ function claim_bridge() {
         log "🔍 Attempt ${attempt}/${max_attempts}"
 
         local global_index
-        global_index=$(generate_global_index "$bridge_info" "$source_network_id" "$manipulated_unused_bits" "$manipulated_rollup_id")
+        if [[ "$manipulated_unused_bits" == "true" || "$manipulated_rollup_id" == "true" ]]; then
+            global_index=$(generate_global_index "$bridge_info" "$source_network_id" "$manipulated_unused_bits" "$manipulated_rollup_id")
+        else
+            global_index="$(echo "$bridge_info" | jq -r '.global_index')"
+        fi
         log "🔍 Global index: $global_index"
 
         run claim_call "$bridge_info" "$proof" "$destination_rpc_url" "$bridge_addr" "$global_index"

--- a/tests/aggkit/bridge-e2e-custom-gas.bats
+++ b/tests/aggkit/bridge-e2e-custom-gas.bats
@@ -87,7 +87,7 @@ setup() {
     local bridge_tx_hash=$output
 
     # Claim withdrawals (settle them on the L1)
-    process_bridge_claim "$l2_rpc_network_id" "$bridge_tx_hash" "$l2_rpc_network_id" "$l1_bridge_addr" "$aggkit_bridge_url" "$aggkit_bridge_url" "$l1_rpc_url"
+    process_bridge_claim "$l2_rpc_network_id" "$bridge_tx_hash" "$l1_rpc_network_id" "$l1_bridge_addr" "$aggkit_bridge_url" "$aggkit_bridge_url" "$l1_rpc_url"
 
     # Validate that the token of receiver on L1 has increased by the bridge tokens amount
     run verify_balance "$l1_rpc_url" "$gas_token_addr" "$destination_addr" "$initial_receiver_balance" "$ether_value"


### PR DESCRIPTION
Extract the global_index from bridge info, retrieved by the bridge service, unless `manipulated_unused_bits` or `manipulated_rollup_id` is set to `true` (in which case we need to generate malicious `global index`)

### Related PR
https://github.com/agglayer/aggkit/pull/1053