### PR TITLE
feat: refactor optimistic mode for agglayer v0.4.x

### DIFF
--- a/TESTSINVENTORY.md
+++ b/TESTSINVENTORY.md
@@ -30,16 +30,16 @@ Table of tests currently implemented or being implemented in the E2E repository.
 | admin_setLatestPendingCertificate with valid certificate ID | [Link](./tests/agglayer/admin-tests.bats#L139) | |
 | admin_setLatestProvenCertificate with non-existent certificate | [Link](./tests/agglayer/admin-tests.bats#L264) | |
 | admin_setLatestProvenCertificate with valid certificate ID | [Link](./tests/agglayer/admin-tests.bats#L280) | |
-| bridge L2 originated ERC20 from L2 to L1 | [Link](./tests/agglayer/bridges.bats#L139) | |
-| bridge native ETH from L1 to L2 | [Link](./tests/agglayer/bridges.bats#L61) | |
-| bridge native ETH from L2 to L1 | [Link](./tests/agglayer/bridges.bats#L103) | |
+| bridge L2 originated ERC20 from L2 to L1 | [Link](./tests/agglayer/bridges.bats#L119) | |
+| bridge native ETH from L1 to L2 | [Link](./tests/agglayer/bridges.bats#L43) | |
+| bridge native ETH from L2 to L1 | [Link](./tests/agglayer/bridges.bats#L84) | |
 | compare admin and regular API responses for same certificate | [Link](./tests/agglayer/admin-tests.bats#L220) | |
-| query interop_getCertificateHeader on agglayer RPC returns expected fields | [Link](./tests/agglayer/bridges.bats#L225) | |
-| query interop_getEpochConfiguration on agglayer RPC returns expected fields | [Link](./tests/agglayer/bridges.bats#L190) | |
-| query interop_getLatestKnownCertificateHeader on agglayer RPC returns expected fields | [Link](./tests/agglayer/bridges.bats#L206) | |
-| query interop_getLatestPendingCertificateHeader on agglayer RPC returns expected fields | [Link](./tests/agglayer/bridges.bats#L266) | |
-| query interop_getLatestSettledCertificateHeader on agglayer RPC returns expected fields | [Link](./tests/agglayer/bridges.bats#L285) | |
-| query interop_getTxStatus on agglayer RPC for latest settled certificate returns done | [Link](./tests/agglayer/bridges.bats#L247) | |
+| query interop_getCertificateHeader on agglayer RPC returns expected fields | [Link](./tests/agglayer/bridges.bats#L203) | |
+| query interop_getEpochConfiguration on agglayer RPC returns expected fields | [Link](./tests/agglayer/bridges.bats#L168) | |
+| query interop_getLatestKnownCertificateHeader on agglayer RPC returns expected fields | [Link](./tests/agglayer/bridges.bats#L184) | |
+| query interop_getLatestPendingCertificateHeader on agglayer RPC returns expected fields | [Link](./tests/agglayer/bridges.bats#L244) | |
+| query interop_getLatestSettledCertificateHeader on agglayer RPC returns expected fields | [Link](./tests/agglayer/bridges.bats#L263) | |
+| query interop_getTxStatus on agglayer RPC for latest settled certificate returns done | [Link](./tests/agglayer/bridges.bats#L225) | |
 
 ## CDK Erigon Tests
 

--- a/core/helpers/agglayer-certificates-checks.bash
+++ b/core/helpers/agglayer-certificates-checks.bash
@@ -64,6 +64,27 @@ agglayer_certificates_checks_setup() {
                     echo "Retrying block increase check..." >&"$output_file"
                     ;;
 
+                "height_increase")
+                    # Only set first_height once, outside the retry loop
+                    if [[ -z "$first_height" ]]; then
+                        local first_height
+                        first_height=$(cast rpc --rpc-url "$(kurtosis port print "$kurtosis_enclave_name" agglayer aglr-readrpc)" interop_getLatestSettledCertificateHeader 1 | jq -r '.height')
+                        echo "Initial height: $first_height" >&"$output_file"
+                    fi
+
+                    sleep "$retry_interval"
+
+                    local second_height
+                    second_height=$(cast rpc --rpc-url "$(kurtosis port print "$kurtosis_enclave_name" agglayer aglr-readrpc)" interop_getLatestSettledCertificateHeader 1 | jq -r '.height')
+                    echo "Latest height: $second_height" >&"$output_file"
+
+                    if [[ "$second_height" -gt "$first_height" ]]; then
+                        echo "$success_msg: $first_height to $second_height" >&"$output_file"
+                        return 0
+                    fi
+                    echo "Retrying height increase check..." >&"$output_file"
+                    ;;
+
                 *)
                     echo "Error: Unknown check type: $check_type" >&"$output_file"
                     return 1
@@ -147,5 +168,9 @@ agglayer_certificates_checks_setup() {
 
     check_block_increase() {
         wait_for_condition "block_increase" "$timeout" "$retry_interval" "Block number has increased" "Error: Timeout ($timeout s) waiting for block increase"
+    }
+
+    check_height_increase() {
+        wait_for_condition "height_increase" "$timeout" "$retry_interval" "Height number has increased" "Error: Timeout ($timeout s) waiting for height increase"
     }
 }

--- a/core/helpers/agglayer-certificates-checks.bash
+++ b/core/helpers/agglayer-certificates-checks.bash
@@ -1,6 +1,7 @@
 # This script contains a helper function to interact with the agglayer node for certificate and block checks.
 agglayer_certificates_checks_setup() {
     # Helper functions to check output conditions
+    # shellcheck disable=SC1009,SC1073,SC1064,SC1072
     check_non_null() [[ -n "$1" && "$1" != "null" ]]
     check_null() [[ -z "$1" || "$1" == "null" ]]
 

--- a/core/helpers/agglayer-certificates-checks.bash
+++ b/core/helpers/agglayer-certificates-checks.bash
@@ -167,9 +167,6 @@ agglayer_certificates_checks_setup() {
         wait_for_condition "settled_cert" "$timeout" "$retry_interval" "Non-null latest settled certificate" "Error: Timeout ($timeout s) for settled certificate"
     }
 
-    check_block_increase() {
-        wait_for_condition "block_increase" "$timeout" "$retry_interval" "Block number has increased" "Error: Timeout ($timeout s) waiting for block increase"
-    }
 
     check_height_increase() {
         wait_for_condition "height_increase" "$timeout" "$retry_interval" "Height number has increased" "Error: Timeout ($timeout s) waiting for height increase"

--- a/tests/agglayer/bridges.bats
+++ b/tests/agglayer/bridges.bats
@@ -2,31 +2,13 @@
 # bats file_tags=agglayer
 
 setup() {
-    kurtosis_enclave_name=${ENCLAVE_NAME:-"aggkit"}
-
-    l1_private_key=${L1_PRIVATE_KEY:-"12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625"}
-    l1_eth_address=$(cast wallet address --private-key "$l1_private_key")
-    l1_rpc_url=${L1_RPC_URL:-"http://$(kurtosis port print "$kurtosis_enclave_name" el-1-geth-lighthouse rpc)"}
-    l1_bridge_addr=${L1_BRIDGE_ADDR:-"0xD779d520D2F8DdD71Eb131f509f2f8Fa355362ae"}
-    if [[ $(cast code $l2_bridge_addr --rpc-url $l2_rpc_url) == "0x" ]]; then
-        echo "Replacing empty bridge contract address..." >&3
-        l2_bridge_addr=$(_get_bridge_address)
-    fi
-
-    l2_private_key=${L2_PRIVATE_KEY:-"0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"}
-    l2_eth_address=$(cast wallet address --private-key "$l2_private_key")
-    l2_rpc_url=${L2_RPC_URL:-"$(kurtosis port print "$kurtosis_enclave_name" op-el-1-op-geth-op-node-001 rpc)"}
-    l2_bridge_addr=${L2_BRIDGE_ADDR:-"0xD779d520D2F8DdD71Eb131f509f2f8Fa355362ae"}
-    if [[ $(cast code $l2_bridge_addr --rpc-url $l2_rpc_url) == "0x" ]]; then
-        echo "Replacing empty bridge contract address..." >&3
-        l2_bridge_addr=$(_get_bridge_address)
-    fi
+    # shellcheck source=core/helpers/common.bash
+    source "$BATS_TEST_DIRNAME/../../core/helpers/common.bash"
+    _setup_vars
 
     bridge_service_url=${BRIDGE_SERVICE_URL:-"$(kurtosis port print "$kurtosis_enclave_name" zkevm-bridge-service-001 rpc)"}
-    network_id=$(cast call  --rpc-url "$l2_rpc_url" "$l2_bridge_addr" 'networkID()(uint32)')
     claimtxmanager_addr=${CLAIMTXMANAGER_ADDR:-"0x5f5dB0D4D58310F53713eF4Df80ba6717868A9f8"}
     claim_wait_duration=${CLAIM_WAIT_DURATION:-"10m"}
-    tx_receipt_timeout_seconds=${TX_RECEIPT_TIMEOUT_SECONDS:-"60"}
 
     agglayer_rpc_url=${AGGLAYER_RPC_URL:-"$(kurtosis port print "$kurtosis_enclave_name" agglayer aglr-readrpc)"}
 
@@ -70,11 +52,11 @@ _fund_claim_tx_manager() {
     polycli ulxly bridge asset \
             --bridge-address "$l1_bridge_addr" \
             --destination-address "$l2_eth_address" \
-            --destination-network "$network_id" \
+            --destination-network "$l2_network_id" \
             --private-key "$l1_private_key" \
             --rpc-url "$l1_rpc_url" \
             --value "$bridge_amount" \
-            --transaction-receipt-timeout "$tx_receipt_timeout_seconds"
+            --gas-limit 500000
 
     set +e
     polycli ulxly claim asset \
@@ -84,8 +66,7 @@ _fund_claim_tx_manager() {
             --deposit-count "$initial_deposit_count" \
             --deposit-network "0" \
             --bridge-service-url "$bridge_service_url" \
-            --wait "$claim_wait_duration" \
-            --transaction-receipt-timeout "$tx_receipt_timeout_seconds"
+            --wait "$claim_wait_duration"
     set -e
 
     final_l2_balance=$(cast balance --rpc-url "$l2_rpc_url" "$l2_eth_address")
@@ -113,20 +94,19 @@ _fund_claim_tx_manager() {
             --rpc-url "$l2_rpc_url" \
             --value "$bridge_amount" \
             --token-address "$weth_address" \
-            --transaction-receipt-timeout "$tx_receipt_timeout_seconds"
+            --gas-limit 500000
 
     tmp_file=$(mktemp)
-    cast rpc --rpc-url "$agglayer_rpc_url" interop_getLatestPendingCertificateHeader "$network_id" > "$tmp_file"
+    cast rpc --rpc-url "$agglayer_rpc_url" interop_getLatestPendingCertificateHeader "$l2_network_id" > "$tmp_file"
 
     polycli ulxly claim asset \
             --bridge-address "$l1_bridge_addr" \
             --private-key "$l1_private_key" \
             --rpc-url "$l1_rpc_url" \
             --deposit-count "$initial_deposit_count" \
-            --deposit-network "$network_id" \
+            --deposit-network "$l2_network_id" \
             --bridge-service-url "$bridge_service_url" \
-            --wait "$claim_wait_duration" \
-            --transaction-receipt-timeout "$tx_receipt_timeout_seconds"
+            --wait "$claim_wait_duration"
 
     final_l1_balance=$(cast balance --rpc-url "$l1_rpc_url" "$l1_eth_address")
     if [[ $initial_l1_balance == "$final_l1_balance" ]]; then
@@ -172,18 +152,16 @@ _fund_claim_tx_manager() {
             --private-key "$l2_private_key" \
             --rpc-url "$l2_rpc_url" \
             --value "100" \
-            --token-address "$erc20_addr" \
-            --transaction-receipt-timeout "$tx_receipt_timeout_seconds"
+            --token-address "$erc20_addr"
 
     polycli ulxly claim asset \
             --bridge-address "$l1_bridge_addr" \
             --private-key "$l1_private_key" \
             --rpc-url "$l1_rpc_url" \
             --deposit-count "$initial_deposit_count" \
-            --deposit-network "$network_id" \
+            --deposit-network "$l2_network_id" \
             --bridge-service-url "$bridge_service_url" \
-            --wait "$claim_wait_duration" \
-            --transaction-receipt-timeout "$tx_receipt_timeout_seconds"
+            --wait "$claim_wait_duration"
 }
 
 # bats test_tags=agglayer-rpc
@@ -205,7 +183,7 @@ _fund_claim_tx_manager() {
 # bats test_tags=agglayer-rpc
 @test "query interop_getLatestKnownCertificateHeader on agglayer RPC returns expected fields" {
     tmp_file=$(mktemp)
-    cast rpc --rpc-url "$agglayer_rpc_url" interop_getLatestKnownCertificateHeader "$network_id" > "$tmp_file"
+    cast rpc --rpc-url "$agglayer_rpc_url" interop_getLatestKnownCertificateHeader "$l2_network_id" > "$tmp_file"
 
     # Skip the test if for whatever reason there hasn't been a certificate at any point
     if jq -e '. == null' "$tmp_file" ; then
@@ -224,7 +202,7 @@ _fund_claim_tx_manager() {
 # bats test_tags=agglayer-rpc
 @test "query interop_getCertificateHeader on agglayer RPC returns expected fields" {
     tmp_file=$(mktemp)
-    cast rpc --rpc-url "$agglayer_rpc_url" interop_getLatestKnownCertificateHeader "$network_id" > "$tmp_file"
+    cast rpc --rpc-url "$agglayer_rpc_url" interop_getLatestKnownCertificateHeader "$l2_network_id" > "$tmp_file"
 
     # Skip the test if there is no known certificate
     if jq -e '. == null' "$tmp_file" ; then
@@ -246,7 +224,7 @@ _fund_claim_tx_manager() {
 # bats test_tags=agglayer-rpc
 @test "query interop_getTxStatus on agglayer RPC for latest settled certificate returns done" {
     tmp_file=$(mktemp)
-    cast rpc --rpc-url "$agglayer_rpc_url" interop_getLatestSettledCertificateHeader "$network_id" > "$tmp_file"
+    cast rpc --rpc-url "$agglayer_rpc_url" interop_getLatestSettledCertificateHeader "$l2_network_id" > "$tmp_file"
 
     # Skip the test if there is no known certificate
     if jq -e '. == null' "$tmp_file" ; then
@@ -265,7 +243,7 @@ _fund_claim_tx_manager() {
 # bats test_tags=agglayer-rpc
 @test "query interop_getLatestPendingCertificateHeader on agglayer RPC returns expected fields" {
     tmp_file=$(mktemp)
-    cast rpc --rpc-url "$agglayer_rpc_url" interop_getLatestPendingCertificateHeader "$network_id" > "$tmp_file"
+    cast rpc --rpc-url "$agglayer_rpc_url" interop_getLatestPendingCertificateHeader "$l2_network_id" > "$tmp_file"
 
     # Skip the test if there is no pending certificate
     if jq -e '. == null' "$tmp_file" ; then
@@ -284,7 +262,7 @@ _fund_claim_tx_manager() {
 # bats test_tags=agglayer-rpc
 @test "query interop_getLatestSettledCertificateHeader on agglayer RPC returns expected fields" {
     tmp_file=$(mktemp)
-    cast rpc --rpc-url "$agglayer_rpc_url" interop_getLatestSettledCertificateHeader "$network_id" > "$tmp_file"
+    cast rpc --rpc-url "$agglayer_rpc_url" interop_getLatestSettledCertificateHeader "$l2_network_id" > "$tmp_file"
 
     if jq -e '. == null' "$tmp_file" ; then
         skip

--- a/tests/op/optimistic-mode.bats
+++ b/tests/op/optimistic-mode.bats
@@ -9,7 +9,7 @@ setup() {
     l2_node_url=${L2_NODE_URL:-"$(kurtosis port print "$kurtosis_enclave_name" op-cl-1-op-node-op-geth-001 http)"}
     rollup_manager_address=${ROLLUP_MANAGER_ADDRESS:-"0x6c6c009cC348976dB4A908c92B24433d4F6edA43"}
     rollup_address=${ROLLUP_ADDRESS:-"0x414e9E227e4b589aF92200508aF5399576530E4e"}
-    optimistic_mode_manager_pvk=${OPTIMISTIC_MODE_MANAGER_PVK:-"0xa574853f4757bfdcbb59b03635324463750b27e16df897f3d00dc6bef2997ae0"}
+    optimistic_mode_manager_pvk=${OPTIMISTIC_MODE_MANAGER_PVK:-"0x12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625"}
     timeout=${TIMEOUT:-3000}
     retry_interval=${RETRY_INTERVAL:-15}
 
@@ -95,8 +95,8 @@ check_fep_consensus_version() {
     wait_for_null_cert >&3
 
     echo "Checking last settled certificate" >&3
-    latest_settled_l2_block=$(cast rpc --rpc-url "$(kurtosis port print "$kurtosis_enclave_name" agglayer aglr-readrpc)" interop_getLatestSettledCertificateHeader 1 | jq -r '.metadata' | perl -e '$_=<>; s/^\s+|\s+$//g; s/^0x//; $_=pack("H*",$_); my ($v,$f,$o,$c)=unpack("C Q> L> L>",$_); printf "{\"v\":%d,\"f\":%d,\"o\":%d,\"c\":%d}\n", $v, $f, $o, $c' | jq '.f + .o')
-    echo "Latest settled L2 block: $latest_settled_l2_block" >&3
+    latest_settled_agglayer_height=$(cast rpc --rpc-url "$(kurtosis port print "$kurtosis_enclave_name" agglayer aglr-readrpc)" interop_getLatestSettledCertificateHeader 1 | jq -r '.height')
+    echo "Latest settled L2 height: $latest_settled_agglayer_height" >&3
 
     cast rpc --rpc-url "$l2_node_url" admin_stopSequencer >stop.out
     kurtosis service stop "$kurtosis_enclave_name" aggkit-001 >&3
@@ -123,7 +123,7 @@ check_fep_consensus_version() {
     manage_bridge_spammer "start"
     kurtosis service start "$kurtosis_enclave_name" aggkit-001 >&3
 
-    check_block_increase >&3
+    check_height_increase >&3
     print_settlement_info >&3
 
     wait_for_null_cert >&3


### PR DESCRIPTION
# Description

Previously for the `optimistic-mode.bats` test, we were relying on the `metadata` field returned from calling `interop_getLatestSettledCertificateHeader`

```
$ cast rpc --rpc-url "$(kurtosis port print op agglayer aglr-readrpc)" interop_getLatestSettledCertificateHeader 1 | jq '.'
{
  "network_id": 1,
  "height": 15,
  "epoch_number": 144,
  "certificate_index": 0,
  "certificate_id": "0xcdd12c5c3bba5c956fe9517d7f113c95b291f85517587b3d425100696175c038",
  "prev_local_exit_root": "0x11e29d15e77a75197fc51639abbdb76de9135db445423d6bfc1530036d957167",
  "new_local_exit_root": "0x6e21a951e3beb2a39f6acaf679d06f545a0cec9f2806bfca962a2c069516d2d7",
  "metadata": "0x0000000000000000000000000000000000000000000000000000000000000000",
  "status": "Settled",
  "settlement_tx_hash": "0x42531f2e3fc9a734bffd256c5d54f14545487f1367a3737a1352f4be4fb81056"
}
```

With `agglayer v0.4.x` the `metadata` field is empty, so the logic to check for settlement increase needs changing as well - in this PR, we're using `height` field instead of the `metadata` field to check for settled certificate increases. This should be okay on a single `op-fep` network, but might not be accurate in multinetwork scenarios if there are other networks attempting to settle certificates on the agglayer.

## Testing

Tested on the integrations branch with `op-fep` mode

<img width="1055" height="897" alt="image" src="https://github.com/user-attachments/assets/54501115-1b94-4745-adae-d6908aa15b09" />
