### PR TITLE
feat: allow aggkit to provide its own kurtosis config templates

### DIFF
--- a/.github/workflows/aggkit-e2e-multi-chains.yml
+++ b/.github/workflows/aggkit-e2e-multi-chains.yml
@@ -65,6 +65,12 @@ on:
         type: number
         default: 2
 
+      aggkit-config-artifact:
+        description: "Optional artifact name holding aggkit-owned kurtosis config templates (aggkit-config.template.toml / aggkit-cdk-config.template.toml). When set, they are overlaid on kurtosis-cdk's static_files before the package runs, letting aggkit own its e2e config without a kurtosis-cdk change."
+        required: false
+        type: string
+        default: ""
+
 permissions:
   contents: read
   packages: write
@@ -143,6 +149,27 @@ jobs:
           if [[ ${{ inputs.number-of-chains }} -eq 3 ]]; then
             echo '${{ inputs.kurtosis-cdk-args-3 }}' | jq --arg img '${{ inputs.docker-image-override }}' --arg tag '${{ inputs.docker-tag }}' '.args[$img] = $tag' | tee /tmp/kurtosis-args-3.json
           fi
+
+      # Let aggkit own its e2e config: overlay the aggkit-provided config
+      # templates onto kurtosis-cdk's static_files before the package renders
+      # them. No-op when the input is unset (other consumers are unaffected).
+      - name: Download aggkit config override
+        if: inputs.aggkit-config-artifact != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.aggkit-config-artifact }}
+          path: /tmp/aggkit-config
+      - name: Apply aggkit config override
+        if: inputs.aggkit-config-artifact != ''
+        run: |
+          set -eo pipefail
+          dst=kurtosis-cdk/static_files/chain/shared/aggkit
+          cp /tmp/aggkit-config/aggkit-config.template.toml "$dst/config.toml"
+          if [[ -f /tmp/aggkit-config/aggkit-cdk-config.template.toml ]]; then
+            cp /tmp/aggkit-config/aggkit-cdk-config.template.toml "$dst/cdk-config.toml"
+          fi
+          echo "Applied aggkit-owned config templates over kurtosis-cdk static_files:"
+          ls -l "$dst"
 
       - name: Startup the kurtosis-cdk package
         run: |

--- a/.github/workflows/aggkit-e2e-single-chain.yml
+++ b/.github/workflows/aggkit-e2e-single-chain.yml
@@ -64,6 +64,12 @@ on:
         type: boolean
         default: true
 
+      aggkit-config-artifact:
+        description: "Optional artifact name holding aggkit-owned kurtosis config templates (aggkit-config.template.toml / aggkit-cdk-config.template.toml). When set, they are overlaid on kurtosis-cdk's static_files before the package runs, letting aggkit own its e2e config without a kurtosis-cdk change."
+        required: false
+        type: string
+        default: ""
+
 permissions:
   contents: read
   packages: write
@@ -130,6 +136,27 @@ jobs:
           fi
           echo '${{ inputs.kurtosis-cdk-args }}'
           echo '${{ inputs.kurtosis-cdk-args }}' | jq --arg img '${{ inputs.docker-image-override }}' --arg tag '${{ inputs.docker-tag }}' '.args[$img] = $tag' | tee /tmp/kurtosis-args.json
+
+      # Let aggkit own its e2e config: overlay the aggkit-provided config
+      # templates onto kurtosis-cdk's static_files before the package renders
+      # them. No-op when the input is unset (other consumers are unaffected).
+      - name: Download aggkit config override
+        if: inputs.aggkit-config-artifact != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.aggkit-config-artifact }}
+          path: /tmp/aggkit-config
+      - name: Apply aggkit config override
+        if: inputs.aggkit-config-artifact != ''
+        run: |
+          set -eo pipefail
+          dst=kurtosis-cdk/static_files/chain/shared/aggkit
+          cp /tmp/aggkit-config/aggkit-config.template.toml "$dst/config.toml"
+          if [[ -f /tmp/aggkit-config/aggkit-cdk-config.template.toml ]]; then
+            cp /tmp/aggkit-config/aggkit-cdk-config.template.toml "$dst/cdk-config.toml"
+          fi
+          echo "Applied aggkit-owned config templates over kurtosis-cdk static_files:"
+          ls -l "$dst"
 
       - name: Startup the kurtosis-cdk package
         run: |


### PR DESCRIPTION
## Summary

Adds an optional `aggkit-config-artifact` input to the aggkit reusable e2e workflows (`aggkit-e2e-single-chain.yml` and `aggkit-e2e-multi-chains.yml`). When set, the named artifact — holding aggkit-owned kurtosis config templates (`aggkit-config.template.toml` / `aggkit-cdk-config.template.toml`) — is downloaded and overlaid onto kurtosis-cdk's `static_files/chain/shared/aggkit/{config,cdk-config}.toml` **after checkout and before `kurtosis run`**.

## Why

Today the aggkit config used by the kurtosis-cdk based Bats e2e lives only in kurtosis-cdk's static templates. Any aggkit config change (e.g. renaming `[REST]` → `[PublicREST]`/`[AdminREST]`) requires a separate kurtosis-cdk PR + a pinned-commit bump before aggkit CI can go green — a recurring multi-PR dance.

This lets the **aggkit repo own its e2e config**: config changes ship in the same aggkit PR as the code, with no kurtosis-cdk change and no pin bump. kurtosis-cdk keeps its own copy as the "released" config that other repos use; aggkit propagates to it on release.

## Behavior / blast radius

- The input is **optional**, default `""`. When empty, the new steps are skipped and behavior is byte-for-byte unchanged — **every other consumer of these workflows is unaffected**.
- The templates remain Go `text/template` files rendered by kurtosis-cdk's `_build_config_data`; they are only overlaid, not reinterpreted.
- Uses the same artifact upload/download pattern already used for `aggsender-find-imported-bridge-artifact`.

## Consumer side (follow-up in aggkit)

The aggkit repo hosts the templates under `test/e2e/kurtosis/`, uploads them as the `aggkit-e2e-config` artifact, and passes `aggkit-config-artifact: aggkit-e2e-config` to these workflows. That aggkit change pins `agglayer-e2e-ref` to this PR's merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)