### PR TITLE
fix(ci): remove empty ${{ }} expression breaking bridge-test workflow

### DIFF
--- a/.github/workflows/standard-bridge-tests-rpc-dispatch.yml
+++ b/.github/workflows/standard-bridge-tests-rpc-dispatch.yml
@@ -244,9 +244,10 @@ jobs:
             set +a
           fi
 
-          # Reference the job-level env vars directly ($VAR), NOT via ${{ }}
-          # interpolation, so secret values are never spliced into this script's
-          # source (avoids the standard Actions shell-injection surface).
+          # Reference the job-level env vars directly ($VAR), NOT via GitHub
+          # Actions expression interpolation, so secret values are never spliced
+          # into this script's source (avoids the standard Actions shell-injection
+          # surface).
           # L1 (network 0)
           export SEPOLIA_RPC_URL="$SEPOLIA_RPC_ENDPOINT"
           export SEPOLIA_PRIVATE_KEY="$L1_FUNDED_PRIVATE_KEY"


### PR DESCRIPTION
- The "Validate root wallet funding" step (added in #262) had a shell comment reading "NOT via ${{ }}". GitHub Actions interpolates ${{ }} expressions anywhere inside a run